### PR TITLE
pass arguments as JSON array to process probe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/chaoslib/__init__.py
+++ b/chaoslib/__init__.py
@@ -9,7 +9,7 @@ __all__ = ["__version__", "substitute"]
 __version__ = '0.14.0'
 
 
-def substitute(data: Union[str, Dict[str, Any], List], 
+def substitute(data: Union[str, Dict[str, Any], List],
                configuration: Configuration,
                secrets: Secrets) -> Dict[str, Any]:
     """

--- a/chaoslib/__init__.py
+++ b/chaoslib/__init__.py
@@ -9,7 +9,8 @@ __all__ = ["__version__", "substitute"]
 __version__ = '0.14.0'
 
 
-def substitute(data: Union[str, Dict[str, Any], List], configuration: Configuration,
+def substitute(data: Union[str, Dict[str, Any], List], 
+               configuration: Configuration,
                secrets: Secrets) -> Dict[str, Any]:
     """
     Replace forms such as `${name}` with the first value found in either the
@@ -36,7 +37,7 @@ def substitute(data: Union[str, Dict[str, Any], List], configuration: Configurat
 
     if isinstance(data, str):
         return substitute_string(data, mapping)
-    
+
     if isinstance(data, list):
         return substitute_in_sequence(data, mapping)
 

--- a/chaoslib/__init__.py
+++ b/chaoslib/__init__.py
@@ -9,7 +9,7 @@ __all__ = ["__version__", "substitute"]
 __version__ = '0.14.0'
 
 
-def substitute(data: Union[str, Dict[str, Any]], configuration: Configuration,
+def substitute(data: Union[str, Dict[str, Any], List], configuration: Configuration,
                secrets: Secrets) -> Dict[str, Any]:
     """
     Replace forms such as `${name}` with the first value found in either the
@@ -36,6 +36,9 @@ def substitute(data: Union[str, Dict[str, Any]], configuration: Configuration,
 
     if isinstance(data, str):
         return substitute_string(data, mapping)
+    
+    if isinstance(data, list):
+        return substitute_in_sequence(data, mapping)
 
     return data
 

--- a/chaoslib/provider/process.py
+++ b/chaoslib/provider/process.py
@@ -52,7 +52,7 @@ def run_process_activity(activity: Activity, configuration: Configuration,
             stderr=subprocess.PIPE, env=os.environ)
     except subprocess.TimeoutExpired:
         raise FailedActivity("process activity took too long to complete")
-    
+
     return (
         proc.returncode,
         proc.stdout.decode('utf-8'),

--- a/chaoslib/provider/process.py
+++ b/chaoslib/provider/process.py
@@ -37,8 +37,12 @@ def run_process_activity(activity: Activity, configuration: Configuration,
     if configuration or secrets:
         arguments = substitute(arguments, configuration, secrets)
 
-    chain = itertools.chain.from_iterable(arguments.items())
-    args = list([p for p in chain if p not in (None, "")])
+    if isinstance(arguments, dict):
+        chain = itertools.chain.from_iterable(arguments.items())
+    else:
+        chain = arguments
+
+    args = list([str(p) for p in chain if p not in (None, "")])
     args.insert(0, shutil.which(provider["path"]))
 
     try:
@@ -48,13 +52,12 @@ def run_process_activity(activity: Activity, configuration: Configuration,
             stderr=subprocess.PIPE, env=os.environ)
     except subprocess.TimeoutExpired:
         raise FailedActivity("process activity took too long to complete")
-
+    
     return (
         proc.returncode,
         proc.stdout.decode('utf-8'),
         proc.stderr.decode('utf-8')
     )
-
 
 def validate_process_activity(activity: Activity):
     """

--- a/chaoslib/provider/process.py
+++ b/chaoslib/provider/process.py
@@ -59,6 +59,7 @@ def run_process_activity(activity: Activity, configuration: Configuration,
         proc.stderr.decode('utf-8')
     )
 
+
 def validate_process_activity(activity: Activity):
     """
     Validate a process activity.

--- a/tests/fixtures/probes.py
+++ b/tests/fixtures/probes.py
@@ -198,26 +198,6 @@ ProcProbe = {
     }
 }
 
-ProcEchoDictProbe = {
-    "type": "probe",
-    "name": "This probe is a process probe that simply echoes its arguments passed as a dict",
-    "pauses": {
-        "before": 0,
-        "after": 0.1
-    },
-    "provider": {
-        "type": "process",
-        "path": sys.executable,
-        "arguments": {
-            "-c": "import sys; print(sys.argv)",
-            "--empty": None,
-            "--number": 1,
-            "--string": "with spaces" 
-        },
-        "timeout": 1
-    }
-}
-
 ProcEchoArrayProbe = {
     "type": "probe",
     "name": "This probe is a process probe that simply echoes its arguments passed as an array",

--- a/tests/fixtures/probes.py
+++ b/tests/fixtures/probes.py
@@ -198,6 +198,47 @@ ProcProbe = {
     }
 }
 
+ProcEchoDictProbe = {
+    "type": "probe",
+    "name": "This probe is a process probe that simply echoes its arguments passed as a dict",
+    "pauses": {
+        "before": 0,
+        "after": 0.1
+    },
+    "provider": {
+        "type": "process",
+        "path": sys.executable,
+        "arguments": {
+            "-c": "import sys; print(sys.argv)",
+            "--empty": None,
+            "--number": 1,
+            "--string": "with spaces" 
+        },
+        "timeout": 1
+    }
+}
+
+ProcEchoArrayProbe = {
+    "type": "probe",
+    "name": "This probe is a process probe that simply echoes its arguments passed as an array",
+    "pauses": {
+        "before": 0,
+        "after": 0.1
+    },
+    "provider": {
+        "type": "process",
+        "path": sys.executable,
+        "arguments": [
+            "-c", "import sys; print(sys.argv)",
+            "--empty",
+            "--number", 1,
+            "--string", "with spaces",
+            "--string", "a second string with the same option"
+        ],
+        "timeout": 1
+    }
+}
+
 HTTPProbe = {
     "type": "probe",
     "name": "This probe is a HTTP probe",

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -100,6 +100,21 @@ def test_run_process_probe_should_return_raw_value():
     assert type(result) is tuple
     assert result == (0, v, '')
 
+def test_run_process_probe_should_pass_arguments_in_dict():
+    args = "['-c', '--empty', '--number', '1', '--string', 'with spaces']\n"
+
+    result = run_activity(
+        probes.ProcEchoDictProbe, config.EmptyConfig, experiments.Secrets)
+    assert type(result) is tuple
+    assert result == (0, args, '')
+
+def test_run_process_probe_should_pass_arguments_in_array():
+    args = "['-c', '--empty', '--number', '1', '--string', 'with spaces', '--string', 'a second string with the same option']\n"
+
+    result = run_activity(
+        probes.ProcEchoArrayProbe, config.EmptyConfig, experiments.Secrets)
+    assert type(result) is tuple
+    assert result == (0, args, '')
 
 def test_run_process_probe_can_timeout():
     probe = probes.ProcProbe

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -100,14 +100,6 @@ def test_run_process_probe_should_return_raw_value():
     assert type(result) is tuple
     assert result == (0, v, '')
 
-def test_run_process_probe_should_pass_arguments_in_dict():
-    args = "['-c', '--empty', '--number', '1', '--string', 'with spaces']\n"
-
-    result = run_activity(
-        probes.ProcEchoDictProbe, config.EmptyConfig, experiments.Secrets)
-    assert type(result) is tuple
-    assert result == (0, args, '')
-
 def test_run_process_probe_should_pass_arguments_in_array():
     args = "['-c', '--empty', '--number', '1', '--string', 'with spaces', '--string', 'a second string with the same option']\n"
 


### PR DESCRIPTION
This PR allows for more freedom in passing arguments to a process probe.
For example: when running a docker container, it is possible to pass in environment variables through
the -e cmdline option. If you need to add more than one option, you just add multiple -e arguments. I have a few simple docker containers that implement a probe, but configuring multiple -e arguments in the experiment JSON to the container is not possible in a JSON object.

By also allowing the arguments object in the probe configuration to be an array, you can pass any argument you like, without being confined to the option:value structure. See ProcEchoArrayProbe in tests/probes.py for an example.
