### PR TITLE
List installed extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+-  listing installed Chaos Toolkit extensions [#64][64]
 -  log (at DEBUG level) which Python file holds an activity or control provider
    function [#59][59]
 -  add controls to provide entry points into the execution flow to perform
@@ -58,6 +59,7 @@
     ]
     ```
 
+[64]: https://github.com/chaostoolkit/chaostoolkit/issues/64
 [59]: https://github.com/chaostoolkit/chaostoolkit-lib/issues/59
 [84]: https://github.com/chaostoolkit/chaostoolkit/issues/84
 

--- a/chaoslib/info.py
+++ b/chaoslib/info.py
@@ -1,0 +1,56 @@
+from collections import namedtuple
+from email import message_from_string
+from typing import Any, Dict, List
+
+from pkg_resources import Environment
+
+__all__ = ["list_extensions"]
+
+
+info_fields = ['name', 'version', 'summary', 'license', 'author', 'url']
+
+
+class ExtensionInfo(namedtuple('ExtensionInfo', info_fields)):
+    __slots__ = ()
+
+
+def list_extensions() -> List[ExtensionInfo]:
+    """
+    List all installed Chaos Toolkit extensions in the current environment.
+
+    Notice, for now we can only list extensions that start with `chaostoolkit-`
+    in their package name.
+
+    This is not as powerful and solid as we want it to be. The trick is that we
+    can't rely on any metadata inside extensions to tell us they exist and
+    what functionnality they provide either. Python has the concept of trove
+    classifiers on packages but we can't extend them yet so they are of no use
+    to us.
+
+    In a future version, we will provide a mechanism from packages to support
+    a better detection.
+    """
+    infos = []
+    distros = Environment()
+    seen = []
+    for key in distros:
+        for dist in distros[key]:
+            if dist.has_metadata('PKG-INFO'):
+                m = dist.get_metadata('PKG-INFO')
+                info = message_from_string(m)
+                name = info["Name"]
+                if name == "chaostoolkit-lib":
+                    continue
+                if name in seen:
+                    continue
+                seen.append(name)
+                if name.startswith("chaostoolkit-"):
+                    ext = ExtensionInfo(
+                        name=name,
+                        version=info["Version"],
+                        summary=info["Summary"],
+                        license=info["License"],
+                        author=info["Author"],
+                        url=info["Home-page"])
+                    infos.append(ext)
+    return infos

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 logzero
 requests
 pyyaml
+setuptools

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,0 +1,55 @@
+from email import message_from_string
+from unittest.mock import MagicMock, patch
+
+from pkg_resources import Distribution, EmptyProvider, Environment
+
+from chaoslib.info import list_extensions
+
+
+class InMemoryMetadata(EmptyProvider):
+    def __init__(self, metadata, *args, **kwargs):
+        EmptyProvider.__init__(self, *args, **kwargs)
+        self._data = metadata
+
+    def has_metadata(self, name):
+        return name in self._data
+
+    def get_metadata(self, name):
+        return self._data.get(name)
+
+
+@patch("chaoslib.info.Environment", autospec=True)
+def test_list_none_when_none_installed(environment: Environment):
+    extensions = list_extensions()
+    assert extensions == []
+
+
+@patch("chaoslib.info.Environment", autospec=True)
+def test_list_one_installed(environment: Environment):
+    env = Environment(search_path=[])
+    environment.return_value = env
+    metadata = """Metadata-Version: 2.1
+Name: chaostoolkit-some-stuff
+Version: 0.1.0
+Summary: Chaos Toolkit some package
+Home-page: http://chaostoolkit.org
+Author: chaostoolkit Team
+Author-email: contact@chaostoolkit.org
+License: Apache License 2.0
+"""
+
+    env.add(
+        Distribution(
+            project_name="chaostoolkit-some-stuff",
+            version="0.1.0",
+            metadata=InMemoryMetadata({
+                "PKG-INFO": metadata
+            })
+        )
+    )
+    extensions = list_extensions()
+    assert len(extensions) == 1
+
+    ext = extensions[0]
+    assert ext.name == "chaostoolkit-some-stuff"
+    assert ext.version == "0.1.0"


### PR DESCRIPTION
List existing extensions those starting with `chaostoolkit-` until we come up with a better metadata signalling. Probably past 1.0.0.