### PR TITLE
Add approle authentication support for Hashicorp Vault secrets

### DIFF
--- a/chaoslib/secret.py
+++ b/chaoslib/secret.py
@@ -142,11 +142,17 @@ def load_secrets_from_vault(secrets_info: Dict[str, Dict[str, str]],
     secrets = {}
 
     url = configuration.get("vault_addr")
-    token = configuration.get("vault_token")
-
     client = None
-    if HAS_HVAC:
-        client = hvac.Client(url=url, token=token)
+    if "vault_token" in configuration.keys():
+        token = configuration.get("vault_token")
+        if HAS_HVAC:
+            client = hvac.Client(url=url, token=token)
+    elif "vault_role_id" in configuration.keys() and "vault_role_secret" in configuration.keys():
+        role_id = configuration.get("vault_role_id")
+        role_secret = configuration.get("vault_role_secret")
+        if HAS_HVAC:
+            client = hvac.Client(url=url)
+            client.token = client.auth_approle(role_id, role_secret)['auth']['client_token']
 
     for (target, keys) in secrets_info.items():
         secrets[target] = {}

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -2,8 +2,9 @@
 import os
 
 import pytest
+from unittest.mock import ANY, MagicMock, patch
 
-from chaoslib.secret import load_secrets
+from chaoslib.secret import load_secrets, create_vault_client
 
 from fixtures import config
 
@@ -45,3 +46,43 @@ def test_should_merge_properly():
     assert secrets["kubernetes"]["address"]["host"] == "whatever"
     assert secrets["kubernetes"]["address"]["port"] == 8090
     assert secrets["kubernetes"]["api_server_url"] == "http://1.2.3.4"
+
+
+@patch('chaoslib.secret.hvac')
+def test_should_auth_with_approle(hvac):
+    config = {
+        'vault_addr' : 'http://someaddr.com',
+        'vault_role_id' : 'mighty_id',
+        'vault_role_secret' : 'secret_secret'
+    }
+
+    fake_auth_object = {
+        'auth' : {
+            'client_token' : 'awesome_token'
+        }
+    }
+
+    fake_client = MagicMock()
+    fake_client.auth_approle.return_value = fake_auth_object
+    hvac.Client.return_value = fake_client
+
+    vault_client = create_vault_client(config)
+
+    assert vault_client.token == fake_auth_object['auth']['client_token']
+    fake_client.auth_approle.assert_called_with(config['vault_role_id'], config['vault_role_secret'])
+
+
+@patch('chaoslib.secret.hvac')
+def test_should_auth_with_token(hvac):
+    config = {
+        'vault_addr': 'http://someaddr.com',
+        'vault_token': 'not_awesome_token',
+    }
+
+    fake_client = MagicMock()
+    hvac.Client.return_value = fake_client
+
+    vault_client = create_vault_client(config)
+
+    assert vault_client.token == config['vault_token']
+    fake_client.auth_approle.assert_not_called()


### PR DESCRIPTION
Its in the best practices of Hashicorp Vault to authenticate with time limited tokens received from approle auth endpoint.
