### PR TITLE
Add Kubernetes service account auth for Vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@
 
 - Fix differences of API between Vault KV secret v1 and v2 [#80][80]
 - Catch Vault AppRole client error [#81][81]
+- Support now [Service Account][serviceaccount] Vault authentication to access Vault secrets [#82][82]
 
 [80]: https://github.com/chaostoolkit/chaostoolkit-lib/issues/80
 [81]: https://github.com/chaostoolkit/chaostoolkit-lib/issues/81
+[82]: https://github.com/chaostoolkit/chaostoolkit-lib/pull/82
 
 ## [1.0.0rc2][] - 2019-01-28
 
@@ -81,6 +83,7 @@
 
 [kvversion]: https://www.vaultproject.io/api/secret/kv/index.html
 [approle]: https://www.vaultproject.io/api/auth/approle/index.html
+[serviceaccount]: https://www.vaultproject.io/api/auth/kubernetes/index.html
 
 ## [1.0.0rc1][] - 2018-11-30
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,18 @@ command:
 $ pip install -U chaostoolkit-lib[vault]
 ```
 
-To authenticate with Vault, you either use a token through the `vault_token`
-configuration key or via an [AppRole][approle] via the `vault_role_id`,
-`vault_secret_id` pair of configuration keys.
+To authenticate with Vault, you can either:
+* Use a token through the `vault_token` configuration key
+* Use an [AppRole][approle] via the `vault_role_id`, `vault_secret_id` pair of configuration keys
+* Use a [service account][serviceaccount] configured with an appropriate [role][role] via the `vault_sa_role` configuration key. The `vault_sa_token_path`, `vault_k8s_mount_point`, and `vault_secrets_mount_point` configuration keys can optionally be specified to point to a location containing a service account [token][sa-token], a different Kubernetes authentication method [mount point][k8s-mount], or a different secrets [mount point][secrets-mount], respectively.
 
 [approle]: https://www.vaultproject.io/docs/auth/approle.html
+[serviceaccount]: https://www.vaultproject.io/api/auth/kubernetes/index.html
+[role]: https://www.vaultproject.io/api/auth/kubernetes/index.html#create-role
+[sa-token]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection
+[k8s-mount]: https://www.vaultproject.io/docs/auth/kubernetes.html
+[secrets-mount]: https://www.vaultproject.io/api/secret/kv/kv-v1.htm
+
 
 ### JSON Path
 


### PR DESCRIPTION
AppRole [support](https://github.com/chaostoolkit/chaostoolkit-lib/pull/74) was just added, and since `chaostoolkit` can be run from within [pods](https://docs.chaostoolkit.org/drivers/kubernetes/#configuration), it would be nice to be able to retrieve secrets from Vault using a configured Kubernetes service account. 

Signed-off-by: mirimi <kathy_huang101@hotmail.com>