### PR TITLE
Setuptools should not be in requirements.txt Issue #107

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 logzero>=1.5.0
 requests>=2.21
 pyyaml>=3.13
-setuptools>=40.6.2


### PR DESCRIPTION
chaostoolkit-lib package successfully and enabling it to run
successfully. However, setuptools is a required to package it
successfulls and hence should not be a part of requirements.txt as when
you run chaos binary, it checks for the specified version of the
packages being installed successfully and fails with setuptools version
since Python3.6 provides it's setuptools by default.