### PR TITLE
Load global controls from experiment run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@
 
 - Fix to ensure a control's `configuration` parameter is populated when it the 
   control is being `configured` [#114][114]
+- Load and apply global controls, those declared in the settings, from the
+  `run_experiment` function rather than out of band [#116][116]
+
+  This means that global controls will not be applied before the experiment
+  is validated but only when it's executed.
+
+  It also means the global controls will be provided with the experiment, its
+  configuration and secrets in case global controls must access these.
+
+[114]: https://github.com/chaostoolkit/chaostoolkit-lib/issues/114
+[116]: https://github.com/chaostoolkit/chaostoolkit-lib/issues/116
+
 
 ## [1.2.0][] - 2019-04-17
 

--- a/chaoslib/caching.py
+++ b/chaoslib/caching.py
@@ -2,11 +2,12 @@
 # Builds an in-memory cache of all declared activities so they can be
 # referenced from other places in the experiment
 from functools import wraps
+import inspect
 from typing import List, Union
 
 from logzero import logger
 
-from chaoslib.types import Activity, Experiment
+from chaoslib.types import Activity, Experiment, Settings
 
 
 __all__ = ["cache_activities", "clear_cache", "lookup_activity", "with_cache"]
@@ -48,11 +49,18 @@ def with_cache(f):
     function.
     """
     @wraps(f)
-    def wrapped(experiment: Experiment):
+    def wrapped(experiment: Experiment, settings: Settings = None):
         try:
             if experiment:
                 cache_activities(experiment)
-            return f(experiment)
+
+            sig = inspect.signature(f)
+            arguments = {
+                "experiment": experiment
+            }
+            if "settings" in sig.parameters:
+                arguments["settings"] = settings
+            return f(**arguments)
         finally:
             clear_cache()
     return wrapped

--- a/chaoslib/control/python.py
+++ b/chaoslib/control/python.py
@@ -28,7 +28,8 @@ _level_mapping = {
 }
 
 
-def initialize_control(control: Control, configuration: Configuration,
+def initialize_control(control: Control, experiment: Experiment,
+                       configuration: Configuration,
                        secrets: Secrets, settings: Settings = None):
     """
     Initialize a control by calling its `configure_control` function.
@@ -39,6 +40,9 @@ def initialize_control(control: Control, configuration: Configuration,
 
     arguments = {}
     sig = inspect.signature(func)
+
+    if "experiment" in sig.parameters:
+        arguments["experiment"] = experiment
 
     if "secrets" in sig.parameters:
         arguments["secrets"] = secrets

--- a/tests/fixtures/controls/dummy.py
+++ b/tests/fixtures/controls/dummy.py
@@ -1,24 +1,19 @@
-import os
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Dict, List
 
 from chaoslib.types import Activity, Configuration, \
     Experiment, Hypothesis, Journal, Run, Secrets, Settings
 
-value_from_config = None
 
-
-def configure_control(configuration: Configuration, secrets: Secrets,
-                      settings: Settings):
-    global value_from_config
+def configure_control(experiment: Experiment, configuration: Configuration,
+                      secrets: Secrets, settings: Settings):
     if configuration:
-        value_from_config = configuration.get("dummy-key", "default")
+        experiment["control-value"] = configuration.get("dummy-key", "default")
     elif settings:
-        value_from_config = settings.get("dummy-key", "default")
+        experiment["control-value"] = settings.get("dummy-key", "default")
 
 
 def cleanup_control():
-    global value_from_config
-    value_from_config = None
+    pass
 
 
 def before_experiment_control(context: Experiment, **kwargs):

--- a/tests/fixtures/controls/dummy_with_failing_cleanup.py
+++ b/tests/fixtures/controls/dummy_with_failing_cleanup.py
@@ -1,0 +1,2 @@
+def cleanup_control():
+    raise RuntimeError("cleanup control")

--- a/tests/fixtures/controls/dummy_with_failing_init.py
+++ b/tests/fixtures/controls/dummy_with_failing_init.py
@@ -1,0 +1,10 @@
+from chaoslib.types import Configuration, Experiment, Secrets, Settings
+
+
+def configure_control(experiment: Experiment, configuration: Configuration,
+                      secrets: Secrets, settings: Settings):
+    raise RuntimeError("init control")
+
+
+def before_experiment_control(context: Experiment, **kwargs):
+    context["should_never_been_called"] = True

--- a/tests/fixtures/experiments.py
+++ b/tests/fixtures/experiments.py
@@ -213,19 +213,9 @@ ExperimentWithVariousTolerances = {
 }
 
 
-
-ExperimentWithControls = {
+ExperimentNoControls = {
     "title": "do cats live in the Internet?",
     "description": "an experiment of importance",
-    "controls": [
-        {
-            "name": "dummy",
-            "provider": {
-                "type": "python",
-                "module": "fixtures.controls.dummy"
-            }
-        }
-    ],
     "steady-state-hypothesis": {
         "title": "hello",
         "probes": [
@@ -238,6 +228,23 @@ ExperimentWithControls = {
     "rollbacks": [
         deepcopy(PythonModuleProbeWithBoolTolerance)
     ]
+}
+
+
+ExperimentWithControls = deepcopy(ExperimentNoControls)
+ExperimentWithControls["controls"] = [
+    {
+        "name": "dummy",
+        "provider": {
+            "type": "python",
+            "module": "fixtures.controls.dummy"
+        }
+    }
+]
+
+ExperimentUsingConfigToConfigureControls = deepcopy(ExperimentNoControls)
+ExperimentUsingConfigToConfigureControls["configuration"] = {
+    "dummy-key": "blah blah"
 }
 
 


### PR DESCRIPTION
The idea is that, by loading them there, we can now pass the
experiment configuration and secrets to them.

Closes #116

Signed-off-by: Sylvain Hellegouarch <sh@defuze.org>