### PR TITLE
Added support for probes in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Prevent control initializations' failure to bubble up
 - Pass arguments to control initialization function when declared
 - Interrupt nicely the experiment from control at the activity level
+- Added support for probes in configuration
 
 ## [1.4.0][] - 2019-05-16
 
@@ -51,7 +52,7 @@
 
 ### Changed
 
-- Fix to ensure a control's `configuration` parameter is populated when it the 
+- Fix to ensure a control's `configuration` parameter is populated when it the
   control is being `configured` [#114][114]
 - Load and apply global controls, those declared in the settings, from the
   `run_experiment` function rather than out of band [#116][116]
@@ -118,7 +119,7 @@
 #### Added
 
 - a new tolerance type called `range` to support scenarios such as:
-  
+
   value type is:
   ```
   {
@@ -483,7 +484,7 @@
 
 ### Changed
 
--   Log a message when loading the configuration 
+-   Log a message when loading the configuration
 -   Raise `InvalidExperiment` when a configuration or secret references a key
     in the environment and that key does not exist (it may not be set however)
     [#40][40]. This bails the experiment at validation time so before it runs.

--- a/chaoslib/configuration.py
+++ b/chaoslib/configuration.py
@@ -4,8 +4,9 @@ from typing import Dict
 
 from logzero import logger
 
-from chaoslib.exceptions import InvalidExperiment
+from chaoslib.exceptions import InvalidExperiment, ChaosException
 from chaoslib.types import Configuration
+from chaoslib.activity import run_activity
 
 __all__ = ["load_configuration"]
 
@@ -13,9 +14,14 @@ __all__ = ["load_configuration"]
 def load_configuration(config_info: Dict[str, str]) -> Configuration:
     """
     Load the configuration. The `config_info` parameter is a mapping from
-    key strings to value as strings or dictionaries. In the former case, the
-    value is used as-is. In the latter case, if the dictionary has a key named
-    `type` alongside a key named `key`.
+    key strings to value as strings or dictionaries. In the cert case, the
+    value is used as-is. In the other cases, if the dictionary has a key named
+    `type` with `env` value, it will take the `key` value from the env
+    variables. If `type` is `probe`, it will take the value from a probe
+    In the probe is of type `process`, the value will be taken from `stdout`
+    In the probe is of type `python`, the value will be taken from the
+    result as is
+    In the probe is of type `http`, the value will be taken from `body`
 
     Here is a sample of what it looks like:
 
@@ -25,6 +31,34 @@ def load_configuration(config_info: Dict[str, str]) -> Configuration:
         "token": {
             "type": "env",
             "key": "MY_TOKEN"
+        },
+        "date": {
+          "type": "probe",
+          "name": "Current date",
+          "provider": {
+            "type": "process",
+            "path": "date"
+          }
+        },
+        "words": {
+          "type": "probe",
+          "name": "Some capped words",
+          "provider": {
+              "type": "python",
+              "module": "string",
+              "func": "capwords",
+              "arguments": {
+                "s": "some words"
+              }
+          }
+        },
+        "valueFromServer": {
+          "type": "probe",
+          "name": "Some value taken from the network",
+          "provider": {
+            "type": "http",
+            "url": "http://my.config.server.com/value"
+         }
         }
     }
     ```
@@ -46,6 +80,17 @@ def load_configuration(config_info: Dict[str, str]) -> Configuration:
                         "Configuration makes reference to an environment key"
                         " that does not exist: {}".format(env_key))
                 conf[key] = env.get(env_key)
+            elif value["type"] == "probe":
+                result = run_activity(value, config_info, {})
+                if value["provider"]["type"] == "process":
+                    conf[key] = result.get("stdout")
+                elif value["provider"]["type"] == "python":
+                    conf[key] = result
+                elif value["provider"]["type"] == "body":
+                    conf[key] = result
+                else:
+                    raise ChaosException(
+                        "Different provider than process not supported yet")
         else:
             conf[key] = value
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -13,8 +13,31 @@ def test_should_load_configuration():
         "token2": {
             "type": "env",
             "key": "KUBE_TOKEN"
+        },
+        "token3": {
+            "type": "probe",
+            "name": "Get some value from a process",
+            "provider": {
+                "type": "process",
+                "path": "echo",
+                "arguments": ["-n", "value3"]
+            }
+        },
+        "token4": {
+            "type": "probe",
+            "name": "Get some value from Python",
+            "provider": {
+                "type": "python",
+                "module": "string",
+                "func": "capwords",
+                "arguments": {
+                    "s": "value4"
+                }
+            }
         }
     })
 
     assert config["token1"] == "value1"
     assert config["token2"] == "value2"
+    assert config["token3"] == "value3"
+    assert config["token4"] == "Value4"


### PR DESCRIPTION
Sample of how the configuration could look like

```
    {
        "cert": "/some/path/file.crt",
        "token": {
            "type": "env",
            "key": "MY_TOKEN"
        },
        "date": {
          "type": "probe",
          "name": "Current date",
          "provider": {
            "type": "process",
            "path": "date"
          }
        },
        "words": {
          "type": "probe",
          "name": "Some capped words",
          "provider": {
              "type": "python",
              "module": "string",
              "func": "capwords",
              "arguments": {
                "s": "some words"
              }
          }
        },
        "valueFromServer": {
          "type": "probe",
          "name": "Some value taken from the network",
          "provider": {
            "type": "http",
            "url": "http://my.config.server.com/value"
         }
        }
    }
```