### PR TITLE
Fix for nested probe in steady-state-probe-tolerance

### DIFF
--- a/chaoslib/hypothesis.py
+++ b/chaoslib/hypothesis.py
@@ -285,8 +285,11 @@ def _(tolerance: dict, value: Any, configuration: Configuration = None,
     if tolerance_type == "probe":
         tolerance["provider"]["arguments"]["value"] = value
         try:
-            run_activity(tolerance, configuration, secrets)
-            return True
+            rtn = run_activity(tolerance, configuration, secrets)
+            if rtn is False:
+                return False
+            else:
+                return True
         except ActivityFailed:
             return False
     elif tolerance_type == "regex":


### PR DESCRIPTION
Hi,

if I understand the chaostoolkit tolerance advanced scenario tutorial \[1\] correct, a nested tolerance probe should be able to return a boolean to indicate the success or failure of that nested probe.

This isn't currently the case and could be patched in with this pull request.

\[1\] https://docs.chaostoolkit.org/reference/tutorials/tolerance/#advanced-scenarios