### PR TITLE
Update hypothesis.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 ### Changed
 
 - Add the `max_retries` parameter to the HTTP provider
+- Changed nested tolerance Python probes to return `True` to the experiment in
+  case the nested probe returns an object or `True`, and to return `False` in
+  case of `None` or `False`. Before, `True` was returned every time except in case
+  of an `ActivityFailed` exception. [#128][128].
 
 ## [1.5.0][] - 2019-07-01
 

--- a/chaoslib/hypothesis.py
+++ b/chaoslib/hypothesis.py
@@ -286,10 +286,10 @@ def _(tolerance: dict, value: Any, configuration: Configuration = None,
         tolerance["provider"]["arguments"]["value"] = value
         try:
             rtn = run_activity(tolerance, configuration, secrets)
-            if rtn is False:
-                return False
-            else:
+            if rtn:
                 return True
+            else:
+                return False
         except ActivityFailed:
             return False
     elif tolerance_type == "regex":

--- a/chaoslib/hypothesis.py
+++ b/chaoslib/hypothesis.py
@@ -285,8 +285,11 @@ def _(tolerance: dict, value: Any, configuration: Configuration = None,
     if tolerance_type == "probe":
         tolerance["provider"]["arguments"]["value"] = value
         try:
-            run_activity(tolerance, configuration, secrets)
-            return True
+            rtn = run_activity(tolerance, configuration, secrets)
+            if rtn is False:
+                return False
+            else:
+                return True
         except ActivityFailed:
             return False
     elif tolerance_type == "regex":

--- a/tests/fixtures/probes.py
+++ b/tests/fixtures/probes.py
@@ -366,3 +366,5 @@ BackgroundPythonModuleProbe = {
 def must_be_in_range(a: int, b: int, value: Any = None) -> bool:
     if not (a < int(value.get("body")) < b):
         raise ActivityFailed("body is not in expected range")
+    else:
+        return True


### PR DESCRIPTION
Hi,

if I understand the chaostoolkit tolerance advanced scenario tutorial \[1\] correct, a nested tolerance probe should be able to return a boolean to indicate the success or failure of that nested probe.

This isn't currently the case and could be patched in with this pull request.

\[1\] https://docs.chaostoolkit.org/reference/tutorials/tolerance/#advanced-scenarios