### PR TITLE
Optional default value for environment variable in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.7.1...HEAD
 
+### Added
+
+- Optional default value for environment variable in configuration
+
 ## [1.7.1][] - 2019-09-27
 
 [1.7.1]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.7.0...1.7.1

--- a/chaoslib/configuration.py
+++ b/chaoslib/configuration.py
@@ -16,6 +16,10 @@ def load_configuration(config_info: Dict[str, str]) -> Configuration:
     key strings to value as strings or dictionaries. In the former case, the
     value is used as-is. In the latter case, if the dictionary has a key named
     `type` alongside a key named `key`.
+    An optional default value is accepted for dictionary value with a key named
+    `default`. The default value will be used only if the environment variable
+    is not defined.
+
 
     Here is a sample of what it looks like:
 
@@ -25,13 +29,20 @@ def load_configuration(config_info: Dict[str, str]) -> Configuration:
         "token": {
             "type": "env",
             "key": "MY_TOKEN"
+        },
+        "host": {
+            "type": "env",
+            "key": "HOSTNAME",
+            "default": "localhost"
         }
     }
     ```
 
     The `cert` configuration key is set to its string value whereas the `token`
     configuration key is dynamically fetched from the `MY_TOKEN` environment
-    variable.
+    variable. The `host` configuration key is dynamically fetched from the
+    `HOSTNAME` environment variable, but if not defined, the default value
+    `localhost` will be used instead.
     """
     logger.debug("Loading configuration...")
     env = os.environ
@@ -41,11 +52,12 @@ def load_configuration(config_info: Dict[str, str]) -> Configuration:
         if isinstance(value, dict) and "type" in value:
             if value["type"] == "env":
                 env_key = value["key"]
-                if env_key not in env:
+                env_default = value.get("default")
+                if env_key not in env and not env_default:
                     raise InvalidExperiment(
                         "Configuration makes reference to an environment key"
                         " that does not exist: {}".format(env_key))
-                conf[key] = env.get(env_key)
+                conf[key] = env.get(env_key, env_default)
         else:
             conf[key] = value
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -13,8 +13,14 @@ def test_should_load_configuration():
         "token2": {
             "type": "env",
             "key": "KUBE_TOKEN"
+        },
+        "token3": {
+            "type": "env",
+            "key": "UNDEFINED",
+            "default": "value3"
         }
     })
 
     assert config["token1"] == "value1"
     assert config["token2"] == "value2"
+    assert config["token3"] == "value3"


### PR DESCRIPTION
Added support for optional default value, when environment variable is not defined.
This is useful when we want to have the experiment working on its own, but with configuration values that can be overridden by environment variables.

As an example, let's say we want to have an experiment that checks for a website URL. As a default, we check for the local developer machine. For remote machine, we can override it with the remote IP/hostname.

```
"host": {
            "type": "env",
            "key": "HOSTNAME",
            "default": "localhost"
        }
```

Signed-off-by: David Martin <david@chaoiq.io>