### PR TITLE
Allow for optional & no-activities method in the experiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Optional default value for environment variable in configuration
 - Warn the user for an action process returning a non-zero exit code 
 
+### Changed
+
+- Changed the method's one-step minimum requirement. 
+  An experiment with an empty method (without any activities) is now valid.
+
 ## [1.7.1][] - 2019-09-27
 
 [1.7.1]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.7.0...1.7.1

--- a/chaoslib/activity.py
+++ b/chaoslib/activity.py
@@ -103,11 +103,14 @@ def run_activities(experiment: Experiment, configuration: Configuration,
                    secrets: Secrets, pool: ThreadPoolExecutor,
                    dry: bool = False) -> Iterator[Run]:
     """
-    Iternal generator that iterates over all activities and execute them.
+    Internal generator that iterates over all activities and execute them.
     Yields either the result of the run or a :class:`concurrent.futures.Future`
     if the activity was set to run in the `background`.
     """
-    method = experiment.get("method")
+    method = experiment.get("method", [])
+
+    if not method:
+        logger.info("No declared activities, let's move on.")
 
     for activity in method:
         if activity.get("background"):

--- a/chaoslib/experiment.py
+++ b/chaoslib/experiment.py
@@ -76,9 +76,12 @@ def ensure_experiment_is_valid(experiment: Experiment):
     ensure_hypothesis_is_valid(experiment)
 
     method = experiment.get("method")
-    if not method:
-        raise InvalidExperiment("an experiment requires a method with "
-                                "at least one activity")
+    if method is None:
+        # we force the method key to be indicated, to make it clear
+        # that the SSH will still be executed before & after the method block
+        raise InvalidExperiment(
+            "an experiment requires a method, "
+            "which can be empty for only checking steady state hypothesis ")
 
     for activity in method:
         ensure_activity_is_valid(activity)
@@ -123,7 +126,7 @@ def get_background_pools(experiment: Experiment) -> ThreadPoolExecutor:
     Create a pool for background activities. The pool is as big as the number
     of declared background activities. If none are declared, returned `None`.
     """
-    method = experiment.get("method")
+    method = experiment.get("method", [])
     rollbacks = experiment.get("rollbacks", [])
 
     activity_background_count = 0

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -67,15 +67,11 @@ def test_unknown_extension():
 def test_experiment_must_have_a_method():
     with pytest.raises(InvalidExperiment) as exc:
         ensure_experiment_is_valid(experiments.MissingMethodExperiment)
-    assert "an experiment requires a method with "\
-           "at least one activity" in str(exc.value)
+    assert "an experiment requires a method" in str(exc.value)
 
 
-def test_experiment_must_have_at_least_one_step():
-    with pytest.raises(InvalidExperiment) as exc:
-        ensure_experiment_is_valid(experiments.NoStepsMethodExperiment)
-    assert "an experiment requires a method with "\
-           "at least one activity" in str(exc.value)
+def test_experiment_method_without_steps():
+    ensure_experiment_is_valid(experiments.NoStepsMethodExperiment)
 
 
 def test_experiment_must_have_a_title():


### PR DESCRIPTION
This PR changes the experiment syntax validation as well as the overall behavior of an experiment.

When I want to check my system with `steady-state-hypothesis` without actually impacting or doing actions on it, I have to create a dummy action as a method. 
I create an activity that does nothing on my system like that:
```
"method":[  
  {  
    "type":"action",
    "name":"dummy-action",
    "provider":{  
      "type":"process",
      "path":"echo",
      "arguments":""
    }
  }
]
```

It would be nice to be able to omit this fake activity to only assert the system capabilities.
This PR is about to accept syntax for both cases:
* optional `method`attribute
* method without activities: `"method": []`


Signed-off-by: David Martin <david@chaoiq.io>