### PR TITLE
Add warning for process returning non-zero code when not in hypothesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 - Optional default value for environment variable in configuration
+- Warn the user for an action process returning a non-zero exit code 
 
 ## [1.7.1][] - 2019-09-27
 

--- a/chaoslib/provider/process.py
+++ b/chaoslib/provider/process.py
@@ -57,6 +57,17 @@ def run_process_activity(activity: Activity, configuration: Configuration,
     except subprocess.TimeoutExpired:
         raise ActivityFailed("process activity took too long to complete")
 
+    # kind warning to the user that this process returned a non--zero
+    # exit code, as traditionally used to indicate a failure,
+    # but not during the hypothesis check because that could also be
+    # exactly what the user want. This warning is helpful during the
+    # method and rollbacks
+    if "tolerance" not in activity and proc.returncode > 0:
+        logger.warning(
+            "This process returned a non-zero exit code. "
+            "This may indicate some error and not what you expected. "
+            "Please have a look at the logs.")
+
     stdout = decode_bytes(proc.stdout)
     stderr = decode_bytes(proc.stderr)
 


### PR DESCRIPTION
Fixes https://github.com/chaostoolkit/chaostoolkit-lib/issues/141

Signed-off-by: David Martin <david@chaosiq.io>