### PR TITLE
Add support for process path relative to homedir (starting with ~)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Optional default value for environment variable in configuration
 - Warn the user for an action process returning a non-zero exit code 
+- Support for process path relative to homedir ~
 
 ### Changed
 

--- a/chaoslib/provider/process.py
+++ b/chaoslib/provider/process.py
@@ -38,7 +38,7 @@ def run_process_activity(activity: Activity, configuration: Configuration,
         arguments = substitute(arguments, configuration, secrets)
 
     shell = False
-    path = shutil.which(provider["path"])
+    path = shutil.which(os.path.expanduser(provider["path"]))
     if isinstance(arguments, str):
         shell = True
         arguments = "{} {}".format(path, arguments)

--- a/tests/test_process_provider.py
+++ b/tests/test_process_provider.py
@@ -1,9 +1,39 @@
 # -*- coding: utf-8 -*-
 import os.path
 from unittest.mock import patch
+import stat
+
 from chaoslib.provider.process import run_process_activity
 
 settings_dir = os.path.join(os.path.dirname(__file__), "fixtures")
+
+# the script path shall be relative to chaostoolkit-lib folder
+dummy_script = './tests/dummy.sh'
+
+
+def setup_module(module):
+    """
+    setup any state specific to the execution of the given module.
+
+    - create the dummy script that can be used as process action
+    """
+    path = './tests/script.sh'
+    with open(dummy_script, 'w') as f:
+        f.write('#!/bin/bash\n')
+        f.write('exit 0\n')
+
+    # gives exec right on the script: chmod +x
+    st = os.stat(dummy_script)
+    os.chmod(dummy_script, st.st_mode | stat.S_IEXEC)
+
+
+def teardown_module(module):
+    """
+    teardown any state that was previously setup with a setup_module method.
+
+    - delete the dummy script, once it's not needed anymore
+    """
+    os.remove(dummy_script)
 
 
 def test_process_not_utf8_cannot_fail():
@@ -20,6 +50,41 @@ def test_process_not_utf8_cannot_fail():
     if result['status'] == 0:
         assert result['stderr'] == u''
         assert result['stdout'] == u'é'
+
+
+def test_process_homedir_relative_path():
+    path = os.path.abspath(dummy_script).replace(
+        os.path.expanduser('~'), '~')
+    result = run_process_activity({
+        "provider": {
+            "type": "process",
+            "path": path,
+            "arguments": ''
+        }
+    }, None, None)
+    assert result['status'] == 0
+
+
+def test_process_absolute_path():
+    result = run_process_activity({
+        "provider": {
+            "type": "process",
+            "path": os.path.abspath(dummy_script),
+            "arguments": ''
+        }
+    }, None, None)
+    assert result['status'] == 0
+
+
+def test_process_cwd_relative_path():
+    result = run_process_activity({
+        "provider": {
+            "type": "process",
+            "path": dummy_script,
+            "arguments": ''
+        }
+    }, None, None)
+    assert result['status'] == 0
 
 
 @patch('chaoslib.provider.process.logger')


### PR DESCRIPTION
fixes https://github.com/chaostoolkit/chaostoolkit-lib/issues/148

Signed-off-by: David Martin <david@chaosiq.io>