### PR TITLE
change deprecated logger.warn to logger.warning

### DIFF
--- a/chaoslib/discovery/discover.py
+++ b/chaoslib/discovery/discover.py
@@ -98,9 +98,10 @@ def discover_activities(extension_mod_name: str,
     try:
         exported = getattr(mod, "__all__")
     except AttributeError:
-        logger.warn("'{m}' does not expose the __all__ attribute. "
-                    "It is required to determine what functions are actually "
-                    "exported as activities.".format(m=extension_mod_name))
+        logger.warning(
+            "'{m}' does not expose the __all__ attribute. "
+            "It is required to determine what functions are actually "
+            "exported as activities.".format(m=extension_mod_name))
         return activities
 
     funcs = inspect.getmembers(mod, inspect.isfunction)

--- a/chaoslib/experiment.py
+++ b/chaoslib/experiment.py
@@ -247,8 +247,8 @@ def run_experiment(experiment: Experiment,
             logger.fatal(str(i))
         except (KeyboardInterrupt, SystemExit):
             journal["status"] = "interrupted"
-            logger.warn("Received an exit signal, "
-                        "leaving without applying rollbacks.")
+            logger.warning("Received an exit signal, "
+                           "leaving without applying rollbacks.")
         else:
             journal["status"] = journal["status"] or "completed"
             try:
@@ -259,7 +259,7 @@ def run_experiment(experiment: Experiment,
                 logger.fatal(str(i))
             except (KeyboardInterrupt, SystemExit):
                 journal["status"] = "interrupted"
-                logger.warn(
+                logger.warning(
                     "Received an exit signal."
                     "Terminating now without running the remaining rollbacks.")
 

--- a/chaoslib/hypothesis.py
+++ b/chaoslib/hypothesis.py
@@ -198,8 +198,8 @@ def run_steady_state_hypothesis(experiment: Experiment,
             if run["status"] == "failed":
                 run["tolerance_met"] = False
                 state["steady_state_met"] = False
-                logger.warn("Probe terminated unexpectedly, "
-                            "so its tolerance could not be validated")
+                logger.warning("Probe terminated unexpectedly, "
+                               "so its tolerance could not be validated")
                 return state
 
             run["tolerance_met"] = True


### PR DESCRIPTION
fixes https://github.com/chaostoolkit/chaostoolkit-lib/issues/105

Signed-off-by: David Martin <david@chaosiq.io>