### PR TITLE
`Chaos discover` for distributions with multiple top-level packages

### DIFF
--- a/chaoslib/discovery/discover.py
+++ b/chaoslib/discovery/discover.py
@@ -28,6 +28,8 @@ def discover(package_name: str, discover_system: bool = True,
     Then apply any post discovery hook that are declared in the chaostoolkit
     settings under the `discovery/post-hook` section.
     """
+    logger.info(f"Discovering capabilities from {package_name}")
+
     if download_and_install:
         install(package_name)
 
@@ -86,7 +88,7 @@ def discover_actions(extension_mod_name: str) -> DiscoveredActivities:
     """
     Discover actions from the given extension named `extension_mod_name`.
     """
-    logger.info("Searching for actions")
+    logger.info(f"Searching for actions in {extension_mod_name}")
     return discover_activities(extension_mod_name, "action")
 
 
@@ -94,7 +96,7 @@ def discover_probes(extension_mod_name: str) -> DiscoveredActivities:
     """
     Discover probes from the given extension named `extension_mod_name`.
     """
-    logger.info("Searching for probes")
+    logger.info(f"Searching for probes in {extension_mod_name}")
     return discover_activities(extension_mod_name, "probe")
 
 


### PR DESCRIPTION
A package (ie distribution package) can contains several packages (aka top-level packages).

The current code fails when the discover function is run against such a distributed package.
The top_level.txt parsing returns a list of more than one package, which cannot be imported as such. 

The purpose of this PR is to be able to handle the multiple top-level packages extensions. It iterates over all the top-level packages to check for discovery function then updates along the chain of packages the discovery result (extending the list of discovered activities)

Do we want to handle such a case, or restrict to one-discoverable-only top-level package from an extension ? 