### PR TITLE
Refactor with importlib metadata

### DIFF
--- a/chaoslib/info.py
+++ b/chaoslib/info.py
@@ -1,8 +1,7 @@
 from collections import namedtuple
-from email import message_from_string
 from typing import List
 
-from pkg_resources import Environment
+import importlib_metadata
 
 __all__ = ["list_extensions"]
 
@@ -31,26 +30,23 @@ def list_extensions() -> List[ExtensionInfo]:
     a better detection.
     """
     infos = []
-    distros = Environment()
+    distros = importlib_metadata.distributions()
     seen = []
-    for key in distros:
-        for dist in distros[key]:
-            if dist.has_metadata('PKG-INFO'):
-                m = dist.get_metadata('PKG-INFO')
-                info = message_from_string(m)
-                name = info["Name"]
-                if name == "chaostoolkit-lib":
-                    continue
-                if name in seen:
-                    continue
-                seen.append(name)
-                if name.startswith("chaostoolkit-"):
-                    ext = ExtensionInfo(
-                        name=name,
-                        version=info["Version"],
-                        summary=info["Summary"],
-                        license=info["License"],
-                        author=info["Author"],
-                        url=info["Home-page"])
-                    infos.append(ext)
+    for dist in distros:
+        info = dist.metadata
+        name = info['Name']
+        if name == "chaostoolkit-lib":
+            continue
+        if name in seen:
+            continue
+        seen.append(name)
+        if name.startswith("chaostoolkit-"):
+            ext = ExtensionInfo(
+                name=name,
+                version=info["Version"],
+                summary=info["Summary"],
+                license=info["License"],
+                author=info["Author"],
+                url=info["Home-page"])
+            infos.append(ext)
     return infos

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 logzero>=1.5.0
 requests>=2.21
 pyyaml>=3.13
+importlib-metadata>=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 logzero>=1.5.0
 requests>=2.21
 pyyaml>=3.13
-importlib-metadata>=1.2.0
+importlib-metadata>=1.2.0; python_version < '3.8'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import os.path
 from tempfile import NamedTemporaryFile
 from typing import Generator
 
-import pkg_resources
 import pytest
 
 from chaoslib.settings import load_settings

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -7,7 +7,6 @@ import tempfile
 from typing import Any, Dict, List
 from unittest.mock import patch
 
-from pkg_resources import Distribution, EntryPoint, working_set
 import logzero
 import pytest
 

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,34 +1,10 @@
-from email import message_from_string
-from unittest.mock import MagicMock, patch
-
-from pkg_resources import Distribution, EmptyProvider, Environment
+from unittest.mock import patch
+from typing import List
+from importlib_metadata import Distribution
 
 from chaoslib.info import list_extensions
 
-
-class InMemoryMetadata(EmptyProvider):
-    def __init__(self, metadata, *args, **kwargs):
-        EmptyProvider.__init__(self, *args, **kwargs)
-        self._data = metadata
-
-    def has_metadata(self, name):
-        return name in self._data
-
-    def get_metadata(self, name):
-        return self._data.get(name)
-
-
-@patch("chaoslib.info.Environment", autospec=True)
-def test_list_none_when_none_installed(environment: Environment):
-    extensions = list_extensions()
-    assert extensions == []
-
-
-@patch("chaoslib.info.Environment", autospec=True)
-def test_list_one_installed(environment: Environment):
-    env = Environment(search_path=[])
-    environment.return_value = env
-    metadata = """Metadata-Version: 2.1
+PGK_META = """Metadata-Version: 2.1
 Name: chaostoolkit-some-stuff
 Version: 0.1.0
 Summary: Chaos Toolkit some package
@@ -38,18 +14,57 @@ Author-email: contact@chaostoolkit.org
 License: Apache License 2.0
 """
 
-    env.add(
-        Distribution(
-            project_name="chaostoolkit-some-stuff",
-            version="0.1.0",
-            metadata=InMemoryMetadata({
-                "PKG-INFO": metadata
-            })
-        )
-    )
+
+class InMemoryDistribution(Distribution):
+    def __init__(self, metadata, *args, **kwargs):
+        Distribution.__init__(self, *args, **kwargs)
+        self._data = metadata
+
+    def read_text(self, filename):
+        return self._data
+
+    def locate_file(self, path):
+        pass
+
+
+@patch("chaoslib.info.importlib_metadata.distributions")
+def test_list_none_when_none_installed(distros: List[Distribution]):
+    distros.return_value = []
+    extensions = list_extensions()
+    assert extensions == []
+
+
+@patch("chaoslib.info.importlib_metadata.distributions")
+def test_list_one_installed(distros: List[Distribution]):
+    distros.return_value = [
+        InMemoryDistribution(PGK_META)
+    ]
+
     extensions = list_extensions()
     assert len(extensions) == 1
 
     ext = extensions[0]
     assert ext.name == "chaostoolkit-some-stuff"
     assert ext.version == "0.1.0"
+
+
+@patch("chaoslib.info.importlib_metadata.distributions")
+def test_list_excludes_ctklib(distros: List[Distribution]):
+    metadata = """Name: chaostoolkit-lib"""
+    distros.return_value = [
+        InMemoryDistribution(metadata)
+    ]
+
+    extensions = list_extensions()
+    assert len(extensions) == 0
+
+
+@patch("chaoslib.info.importlib_metadata.distributions")
+def test_list_skip_duplicates(distros: List[Distribution]):
+    distros.return_value = [
+        InMemoryDistribution(PGK_META),
+        InMemoryDistribution(PGK_META),
+    ]
+
+    extensions = list_extensions()
+    assert len(extensions) == 1


### PR DESCRIPTION
This PR intends to replace the use of pkg_resource package with the new importlib-metadata that is being ported to python 3.8
Accessing distribution packages metadata is easier and better wrapped.