### PR TITLE
Validate all errors

### DIFF
--- a/chaoslib/control/python.py
+++ b/chaoslib/control/python.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, List, Optional, Union
 from logzero import logger
 
 from chaoslib import substitute
-from chaoslib.exceptions import InvalidActivity
+from chaoslib.exceptions import InvalidActivity, ChaosException
 from chaoslib.types import Activity, Configuration, Control, Experiment, \
     Journal, Run, Secrets, Settings
 
@@ -83,16 +83,19 @@ def cleanup_control(control: Control):
     func()
 
 
-def validate_python_control(control: Control):
+def validate_python_control(control: Control) -> List[ChaosException]:
     """
     Verify that a control block matches the specification
     """
+    errors = []
     name = control["name"]
     provider = control["provider"]
     mod_name = provider.get("module")
     if not mod_name:
-        raise InvalidActivity(
-            "Control '{}' must have a module path".format(name))
+        errors.append(InvalidActivity(
+            "Control '{}' must have a module path".format(name)))
+        # can not continue any longer - must exit this function
+        return errors
 
     try:
         importlib.import_module(mod_name)

--- a/chaoslib/exceptions.py
+++ b/chaoslib/exceptions.py
@@ -3,7 +3,7 @@
 __all__ = ["ChaosException", "InvalidExperiment", "InvalidActivity",
            "ActivityFailed", "DiscoveryFailed", "InvalidSource",
            "InterruptExecution", "ControlPythonFunctionLoadingError",
-           "InvalidControl"]
+           "InvalidControl", "ValidationError"]
 
 
 class ChaosException(Exception):
@@ -44,3 +44,30 @@ class InterruptExecution(ChaosException):
 
 class InvalidControl(ChaosException):
     pass
+
+
+class ValidationError(ChaosException):
+    def __init__(self, msg, errors, *args, **kwargs):
+        """
+        :param msg: exception message
+        :param errors: single error as string or list of errors/exceptions
+        """
+        if isinstance(errors, str):
+            errors = [errors]
+        self.errors = errors
+        super().__init__(msg, *args, **kwargs)
+
+    def __str__(self) -> str:
+        errors = self.errors
+        nb_errors = len(errors)
+        err_msg = super().__str__()
+        return (
+            "{msg}{dot} {nb} validation error{plural}:\n"
+            " - {errors}".format(
+                msg=err_msg,
+                dot="" if err_msg.endswith(".") else ".",
+                nb=nb_errors,
+                plural="" if nb_errors == 1 else "s",
+                errors="\n - ".join([str(err) for err in errors])
+            )
+        )

--- a/chaoslib/experiment.py
+++ b/chaoslib/experiment.py
@@ -15,7 +15,7 @@ from chaoslib.control import initialize_controls, controls, cleanup_controls, \
     cleanup_global_controls
 from chaoslib.deprecation import warn_about_deprecated_features
 from chaoslib.exceptions import ActivityFailed, ChaosException, \
-    InterruptExecution, InvalidActivity, InvalidExperiment
+    InterruptExecution, InvalidActivity, InvalidExperiment, ValidationError
 from chaoslib.extension import validate_extensions
 from chaoslib.configuration import load_configuration
 from chaoslib.hypothesis import ensure_hypothesis_is_valid, \
@@ -55,10 +55,14 @@ def ensure_experiment_is_valid(experiment: Experiment):
     """
     logger.info("Validating the experiment's syntax")
 
+    full_validation_msg = 'Experiment is not valid, ' \
+                          'please fix the following errors'
     errors = []
 
     if not experiment:
-        raise InvalidExperiment("an empty experiment is not an experiment")
+        # empty experiment, cannot continue validation any further
+        raise ValidationError(full_validation_msg,
+                              "an empty experiment is not an experiment")
 
     if not experiment.get("title"):
         errors.append(InvalidExperiment("experiment requires a title"))
@@ -103,11 +107,7 @@ def ensure_experiment_is_valid(experiment: Experiment):
     errors.extend(validate_controls(experiment))
 
     if errors:
-        full_validation_msg = 'Experiment is not valid, ' \
-                              'please fix the following errors:'
-        for error in errors:
-            full_validation_msg += '\n- {}'.format(error)
-        raise InvalidExperiment(full_validation_msg)
+        raise ValidationError(full_validation_msg, errors)
 
     logger.info("Experiment looks valid")
 

--- a/chaoslib/experiment.py
+++ b/chaoslib/experiment.py
@@ -48,54 +48,66 @@ def ensure_experiment_is_valid(experiment: Experiment):
     another set of of  ̀close` probes to sense the state of the system
     post-action.
 
-    This function raises :exc:`InvalidExperiment`, :exc:`InvalidProbe` or
-    :exc:`InvalidAction` depending on where it fails.
+    This function raises an :exc:`InvalidExperiment` error
+    if the experiment is not valid.
+    If multiple validation errors are found, the errors are listed
+    as part of the exception message
     """
     logger.info("Validating the experiment's syntax")
+
+    errors = []
 
     if not experiment:
         raise InvalidExperiment("an empty experiment is not an experiment")
 
     if not experiment.get("title"):
-        raise InvalidExperiment("experiment requires a title")
+        errors.append(InvalidExperiment("experiment requires a title"))
 
     if not experiment.get("description"):
-        raise InvalidExperiment("experiment requires a description")
+        errors.append(InvalidExperiment("experiment requires a description"))
 
     tags = experiment.get("tags")
     if tags:
         if list(filter(lambda t: t == '' or not isinstance(t, str), tags)):
-            raise InvalidExperiment(
-                "experiment tags must be a non-empty string")
+            errors.append(InvalidExperiment(
+                "experiment tags must be a non-empty string"))
 
-    validate_extensions(experiment)
+    errors.extend(validate_extensions(experiment))
 
     config = load_configuration(experiment.get("configuration", {}))
     load_secrets(experiment.get("secrets", {}), config)
 
-    ensure_hypothesis_is_valid(experiment)
+    errors.extend(ensure_hypothesis_is_valid(experiment))
 
     method = experiment.get("method")
     if not method:
-        raise InvalidExperiment("an experiment requires a method with "
-                                "at least one activity")
+        errors.append(InvalidExperiment("an experiment requires a method with "
+                                        "at least one activity"))
+    else:
+        for activity in method:
+            errors.extend(ensure_activity_is_valid(activity))
 
-    for activity in method:
-        ensure_activity_is_valid(activity)
-
-        # let's see if a ref is indeed found in the experiment
-        ref = activity.get("ref")
-        if ref and not lookup_activity(ref):
-            raise InvalidActivity("referenced activity '{r}' could not be "
-                                  "found in the experiment".format(r=ref))
+            # let's see if a ref is indeed found in the experiment
+            ref = activity.get("ref")
+            if ref and not lookup_activity(ref):
+                errors.append(
+                    InvalidActivity("referenced activity '{r}' could not be "
+                                    "found in the experiment".format(r=ref)))
 
     rollbacks = experiment.get("rollbacks", [])
     for activity in rollbacks:
-        ensure_activity_is_valid(activity)
+        errors.extend(ensure_activity_is_valid(activity))
 
     warn_about_deprecated_features(experiment)
 
-    validate_controls(experiment)
+    errors.extend(validate_controls(experiment))
+
+    if errors:
+        full_validation_msg = 'Experiment is not valid, ' \
+                              'please fix the following errors:'
+        for error in errors:
+            full_validation_msg += '\n- {}'.format(error)
+        raise InvalidExperiment(full_validation_msg)
 
     logger.info("Experiment looks valid")
 

--- a/chaoslib/extension.py
+++ b/chaoslib/extension.py
@@ -1,25 +1,29 @@
 # -*- coding: utf-8 -*-
-from typing import Optional
+from typing import Optional, List
 
-from chaoslib.exceptions import InvalidExperiment
+from chaoslib.exceptions import InvalidExperiment, ChaosException
 from chaoslib.types import Experiment, Extension
 
 __all__ = ["get_extension", "has_extension", "set_extension",
            "merge_extension", "remove_extension", "validate_extensions"]
 
 
-def validate_extensions(experiment: Experiment):
+def validate_extensions(experiment: Experiment) -> List[ChaosException]:
     """
     Validate that extensions respect the specification.
     """
     extensions = experiment.get("extensions")
     if not extensions:
-        return
+        return []
 
+    errors = []
     for ext in extensions:
         ext_name = ext.get('name')
         if not ext_name or not ext_name.strip():
-            raise InvalidExperiment("All extensions require a non-empty name")
+            errors.append(
+                InvalidExperiment("All extensions require a non-empty name"))
+
+    return errors
 
 
 def get_extension(experiment: Experiment, name: str) -> Optional[Extension]:

--- a/chaoslib/hypothesis.py
+++ b/chaoslib/hypothesis.py
@@ -34,21 +34,25 @@ def ensure_hypothesis_is_valid(experiment: Experiment):
     """
     hypo = experiment.get("steady-state-hypothesis")
     if hypo is None:
-        return
+        return []
 
+    errors = []
     if not hypo.get("title"):
-        raise InvalidExperiment("hypothesis requires a title")
+        errors.append(InvalidExperiment("hypothesis requires a title"))
 
     probes = hypo.get("probes")
     if probes:
         for probe in probes:
-            ensure_activity_is_valid(probe)
+            errors.extend(ensure_activity_is_valid(probe))
 
             if "tolerance" not in probe:
-                raise InvalidActivity(
-                    "hypothesis probe must have a tolerance entry")
+                errors.append(InvalidActivity(
+                    "hypothesis probe must have a tolerance entry"))
+            else:
+                errors.extend(
+                    ensure_hypothesis_tolerance_is_valid(probe["tolerance"]))
 
-            ensure_hypothesis_tolerance_is_valid(probe["tolerance"])
+    return errors
 
 
 def ensure_hypothesis_tolerance_is_valid(tolerance: Tolerance):
@@ -80,6 +84,9 @@ def ensure_hypothesis_tolerance_is_valid(tolerance: Tolerance):
             raise InvalidActivity(
                 "hypothesis probe tolerance type '{}' is unsupported".format(
                     tolerance_type))
+
+    # TODO
+    return []
 
 
 def check_regex_pattern(tolerance: Tolerance):

--- a/chaoslib/provider/http.py
+++ b/chaoslib/provider/http.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-from typing import Any
+from typing import Any, List
 import urllib3
 
 from logzero import logger
 import requests
 
 from chaoslib import substitute
-from chaoslib.exceptions import ActivityFailed, InvalidActivity
+from chaoslib.exceptions import ActivityFailed, InvalidActivity, ChaosException
 from chaoslib.types import Activity, Configuration, Secrets
 
 
@@ -89,7 +89,7 @@ def run_http_activity(activity: Activity, configuration: Configuration,
         raise ActivityFailed("activity took too long to complete")
 
 
-def validate_http_activity(activity: Activity):
+def validate_http_activity(activity: Activity) -> List[ChaosException]:
     """
     Validate a HTTP activity.
 
@@ -102,15 +102,20 @@ def validate_http_activity(activity: Activity):
     * `"method"` which is the HTTP verb to use (default to `"GET"`)
     * `"headers"` which must be a mapping of string to string
 
-    In all failing cases, raises :exc:`InvalidActivity`.
+    In all failing cases, returns a list of errors.
 
     This should be considered as a private function.
     """
+    errors = []
+
     provider = activity["provider"]
     url = provider.get("url")
     if not url:
-        raise InvalidActivity("a HTTP activity must have a URL")
+        errors.append(InvalidActivity("a HTTP activity must have a URL"))
 
     headers = provider.get("headers")
     if headers and not type(headers) == dict:
-        raise InvalidActivity("a HTTP activities expect headers as a mapping")
+        errors.append(
+            InvalidActivity("a HTTP activities expect headers as a mapping"))
+
+    return errors

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -12,6 +12,6 @@ from fixtures import actions
 
 
 def test_empty_action_is_invalid():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(actions.EmptyAction)
-    assert "empty activity is no activity" in str(exc.value)
+    errors = ensure_activity_is_valid(actions.EmptyAction)
+    assert "empty activity is no activity" in str(errors[0])
+

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -232,13 +232,14 @@ def test_validate_python_control_must_be_loadable(logger):
 
 
 def test_validate_python_control_needs_a_module():
-    with pytest.raises(InvalidActivity):
-        validate_python_control({
+    errors = validate_python_control({
             "name": "a-python-control",
             "provider": {
                 "type": "python"
             }
         })
+    assert len(errors)
+    assert type(errors[0]) == InvalidActivity
 
 
 def test_controls_can_access_experiment():

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -102,7 +102,7 @@ def test_experiment_hypothesis_must_have_a_title():
 
 
 def test_experiment_hypothesis_must_have_a_valid_probe():
-    with pytest.raises(InvalidActivity) as exc:
+    with pytest.raises(InvalidExperiment) as exc:
         ensure_experiment_is_valid(experiments.ExperimentWithInvalidHypoProbe)
     assert "required argument 'path' is missing from activity" in str(exc.value)
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -9,10 +9,10 @@ from fixtures import experiments
 
 
 def test_extensions_must_have_name():
-    with pytest.raises(InvalidExperiment):
-        exp = experiments.Experiment.copy()
-        set_extension(exp, {"somekey": "blah"})
-        validate_extensions(exp)
+    exp = experiments.Experiment.copy()
+    set_extension(exp, {"somekey": "blah"})
+    errors = validate_extensions(exp)
+    assert len(errors)
 
 
 def test_get_extension_returns_nothing_when_not_extensions_block():

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -14,77 +14,83 @@ from chaoslib.activity import ensure_activity_is_valid, run_activity
 from fixtures import config, experiments, probes
 
 
+def assert_in_errors(msg, errors):
+    """
+    Check whether msg can be found in any of the list of errors
+
+    :param msg: exception string to be found in any of the instances
+    :param errors: list of ChaosException instances
+    """
+    for error in errors:
+        if msg in str(error):
+            # expected exception message is found
+            return
+
+    raise AssertionError("{} not in {}".format(msg, errors))
+
+
 def test_empty_probe_is_invalid():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.EmptyProbe)
-    assert "empty activity is no activity" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.EmptyProbe)
+    assert_in_errors("empty activity is no activity", errors)
 
 
 def test_probe_must_have_a_type():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.MissingTypeProbe)
-    assert "an activity must have a type" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.MissingTypeProbe)
+    assert_in_errors("an activity must have a type", errors)
 
 
 def test_probe_must_have_a_known_type():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.UnknownTypeProbe)
-    assert "'whatever' is not a supported activity type" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.UnknownTypeProbe)
+    assert_in_errors("'whatever' is not a supported activity type", errors)
 
 
 def test_probe_provider_must_have_a_known_type():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.UnknownProviderTypeProbe)
-    assert "unknown provider type 'pizza'" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.UnknownProviderTypeProbe)
+    assert_in_errors("unknown provider type 'pizza'", errors)
 
 
 def test_python_probe_must_have_a_module_path():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.MissingModuleProbe)
-    assert "a Python activity must have a module path" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.MissingModuleProbe)
+    assert_in_errors("a Python activity must have a module path", errors)
 
 
 def test_python_probe_must_have_a_function_name():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.MissingFunctionProbe)
-    assert "a Python activity must have a function name" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.MissingFunctionProbe)
+    assert_in_errors("a Python activity must have a function name", errors)
 
 
 def test_python_probe_must_be_importable():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.NotImportableModuleProbe)
-    assert "could not find Python module 'fake.module'" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.NotImportableModuleProbe)
+    assert_in_errors("could not find Python module 'fake.module'", errors)
 
 
 def test_python_probe_func_must_have_enough_args():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.MissingFuncArgProbe)
-    assert "required argument 'path' is missing" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.MissingFuncArgProbe)
+    assert_in_errors("required argument 'path' is missing", errors)
 
 
 def test_python_probe_func_cannot_have_too_many_args():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.TooManyFuncArgsProbe)
-    assert "argument 'should_not_be_here' is not part of the " \
-           "function signature" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.TooManyFuncArgsProbe)
+    assert_in_errors(
+        "argument 'should_not_be_here' is not part of the function signature",
+        errors)
 
 
 def test_process_probe_have_a_path():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.MissingProcessPathProbe)
-    assert "a process activity must have a path" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.MissingProcessPathProbe)
+    assert_in_errors("a process activity must have a path", errors)
 
 
 def test_process_probe_path_must_exist():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.ProcessPathDoesNotExistProbe)
-    assert "path 'None' cannot be found, in activity" in str(exc.value)
+    print(probes.ProcessPathDoesNotExistProbe)
+    errors = ensure_activity_is_valid(probes.ProcessPathDoesNotExistProbe)
+    print(errors)
+    assert_in_errors("path 'None' cannot be found, in activity", errors)
 
 
 def test_http_probe_must_have_a_url():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.MissingHTTPUrlProbe)
-    assert "a HTTP activity must have a URL" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.MissingHTTPUrlProbe)
+    assert_in_errors("a HTTP activity must have a URL", errors)
 
 
 def test_run_python_probe_should_return_raw_value():


### PR DESCRIPTION
@Lawouach 
This is the first version of global validation for the experiment syntax.

This is appending/extending a list of Exception instances along the validation line and reporting all errors at once, at the end of experiment validation (before raising a global exception that is matched & logged by the CLI)

Improvement, in this version, for each error we create an instance of a sub class of ChaosException. We might simplify to only handle a list of errors messages as strings.

To be continued, if we choose this solution, the hypothesis module still need to be updated