### PR TITLE
Validate all errors v2

### DIFF
--- a/chaoslib/control/python.py
+++ b/chaoslib/control/python.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, List, Optional, Union
 from logzero import logger
 
 from chaoslib import substitute
-from chaoslib.exceptions import InvalidActivity
+from chaoslib.exceptions import InvalidActivity, ChaosException
 from chaoslib.types import Activity, Configuration, Control, Experiment, \
     Journal, Run, Secrets, Settings
 
@@ -83,16 +83,19 @@ def cleanup_control(control: Control):
     func()
 
 
-def validate_python_control(control: Control):
+def validate_python_control(control: Control) -> List[ChaosException]:
     """
     Verify that a control block matches the specification
     """
+    errors = []
     name = control["name"]
     provider = control["provider"]
     mod_name = provider.get("module")
     if not mod_name:
-        raise InvalidActivity(
-            "Control '{}' must have a module path".format(name))
+        errors.append(InvalidActivity(
+            "Control '{}' must have a module path".format(name)))
+        # can not continue any longer - must exit this function
+        return errors
 
     try:
         importlib.import_module(mod_name)

--- a/chaoslib/exceptions.py
+++ b/chaoslib/exceptions.py
@@ -3,7 +3,7 @@
 __all__ = ["ChaosException", "InvalidExperiment", "InvalidActivity",
            "ActivityFailed", "DiscoveryFailed", "InvalidSource",
            "InterruptExecution", "ControlPythonFunctionLoadingError",
-           "InvalidControl"]
+           "InvalidControl", "ValidationError"]
 
 
 class ChaosException(Exception):
@@ -44,3 +44,30 @@ class InterruptExecution(ChaosException):
 
 class InvalidControl(ChaosException):
     pass
+
+
+class ValidationError(ChaosException):
+    def __init__(self, msg, errors, *args, **kwargs):
+        """
+        :param msg: exception message
+        :param errors: single error as string or list of errors/exceptions
+        """
+        if isinstance(errors, str):
+            errors = [errors]
+        self.errors = errors
+        super().__init__(msg, *args, **kwargs)
+
+    def __str__(self) -> str:
+        errors = self.errors
+        nb_errors = len(errors)
+        err_msg = super().__str__()
+        return (
+            "{msg}{dot} {nb} validation error{plural}:\n"
+            " - {errors}".format(
+                msg=err_msg,
+                dot="" if err_msg.endswith(".") else ".",
+                nb=nb_errors,
+                plural="" if nb_errors == 1 else "s",
+                errors="\n - ".join([str(err) for err in errors])
+            )
+        )

--- a/chaoslib/exceptions.py
+++ b/chaoslib/exceptions.py
@@ -47,27 +47,4 @@ class InvalidControl(ChaosException):
 
 
 class ValidationError(ChaosException):
-    def __init__(self, msg, errors, *args, **kwargs):
-        """
-        :param msg: exception message
-        :param errors: single error as string or list of errors/exceptions
-        """
-        if isinstance(errors, str):
-            errors = [errors]
-        self.errors = errors
-        super().__init__(msg, *args, **kwargs)
-
-    def __str__(self) -> str:
-        errors = self.errors
-        nb_errors = len(errors)
-        err_msg = super().__str__()
-        return (
-            "{msg}{dot} {nb} validation error{plural}:\n"
-            " - {errors}".format(
-                msg=err_msg,
-                dot="" if err_msg.endswith(".") else ".",
-                nb=nb_errors,
-                plural="" if nb_errors == 1 else "s",
-                errors="\n - ".join([str(err) for err in errors])
-            )
-        )
+    pass

--- a/chaoslib/experiment.py
+++ b/chaoslib/experiment.py
@@ -15,7 +15,7 @@ from chaoslib.control import initialize_controls, controls, cleanup_controls, \
     cleanup_global_controls
 from chaoslib.deprecation import warn_about_deprecated_features
 from chaoslib.exceptions import ActivityFailed, ChaosException, \
-    InterruptExecution, InvalidActivity, InvalidExperiment
+    InterruptExecution, InvalidActivity, InvalidExperiment, ValidationError
 from chaoslib.extension import validate_extensions
 from chaoslib.configuration import load_configuration
 from chaoslib.hypothesis import ensure_hypothesis_is_valid, \
@@ -55,10 +55,14 @@ def ensure_experiment_is_valid(experiment: Experiment):
     """
     logger.info("Validating the experiment's syntax")
 
+    full_validation_msg = 'Experiment is not valid, ' \
+                          'please fix the following errors'
     errors = []
 
     if not experiment:
-        raise InvalidExperiment("an empty experiment is not an experiment")
+        # empty experiment, cannot continue validation any further
+        raise ValidationError(full_validation_msg,
+                              "an empty experiment is not an experiment")
 
     if not experiment.get("title"):
         errors.append(InvalidExperiment("experiment requires a title"))
@@ -103,11 +107,7 @@ def ensure_experiment_is_valid(experiment: Experiment):
     errors.extend(validate_controls(experiment))
 
     if errors:
-        full_validation_msg = 'Experiment is not valid, ' \
-                              'please fix the following errors:'
-        for error in errors:
-            full_validation_msg += '\n- {}'.format(error)
-        raise InvalidExperiment(full_validation_msg)
+        raise ValidationError(full_validation_msg, errors)
 
     logger.info("Experiment looks valid")
 

--- a/chaoslib/experiment.py
+++ b/chaoslib/experiment.py
@@ -15,7 +15,8 @@ from chaoslib.control import initialize_controls, controls, cleanup_controls, \
     cleanup_global_controls
 from chaoslib.deprecation import warn_about_deprecated_features
 from chaoslib.exceptions import ActivityFailed, ChaosException, \
-    InterruptExecution, InvalidActivity, InvalidExperiment, ValidationError
+    InterruptExecution, InvalidActivity, InvalidExperiment, \
+    ValidationError as ValidationErrorException
 from chaoslib.extension import validate_extensions
 from chaoslib.configuration import load_configuration
 from chaoslib.hypothesis import ensure_hypothesis_is_valid, \
@@ -25,14 +26,17 @@ from chaoslib.rollback import run_rollbacks
 from chaoslib.secret import load_secrets
 from chaoslib.settings import get_loaded_settings
 from chaoslib.types import Configuration, Experiment, Journal, Run, Secrets, \
-    Settings
+    Settings, ValidationError
+from chaoslib.validation import Validation
 
 initialize_global_controls
 __all__ = ["ensure_experiment_is_valid", "run_experiment", "load_experiment"]
 
 
 @with_cache
-def ensure_experiment_is_valid(experiment: Experiment):
+def ensure_experiment_is_valid(experiment: Experiment,
+                               no_raise: bool = False
+                               ) -> List[ValidationError]:
     """
     A chaos experiment consists of a method made of activities to carry
     sequentially.
@@ -52,62 +56,73 @@ def ensure_experiment_is_valid(experiment: Experiment):
     if the experiment is not valid.
     If multiple validation errors are found, the errors are listed
     as part of the exception message
+
+    If `no_raise` is True, the function will not raise any
+    exception but rather return the list of validation errors
     """
     logger.info("Validating the experiment's syntax")
 
-    full_validation_msg = 'Experiment is not valid, ' \
-                          'please fix the following errors'
-    errors = []
+    full_validation_msg = "Experiment is not valid, " \
+                          "please fix the following errors. " \
+                          "\n{}"
+    v = Validation()
 
     if not experiment:
+        v.add_error("$", "an empty experiment is not an experiment")
         # empty experiment, cannot continue validation any further
-        raise ValidationError(full_validation_msg,
-                              "an empty experiment is not an experiment")
+        if no_raise:
+            return v.errors()
+        raise InvalidExperiment(full_validation_msg.format(str(v)))
 
     if not experiment.get("title"):
-        errors.append(InvalidExperiment("experiment requires a title"))
+        v.add_error("title", "experiment requires a title")
 
     if not experiment.get("description"):
-        errors.append(InvalidExperiment("experiment requires a description"))
+        v.add_error("description", "experiment requires a description")
 
     tags = experiment.get("tags")
     if tags:
         if list(filter(lambda t: t == '' or not isinstance(t, str), tags)):
-            errors.append(InvalidExperiment(
-                "experiment tags must be a non-empty string"))
+            v.add_error("tags", "experiment tags must be a non-empty string")
 
-    errors.extend(validate_extensions(experiment))
+    v.extend_errors(validate_extensions(experiment))
 
     config = load_configuration(experiment.get("configuration", {}))
     load_secrets(experiment.get("secrets", {}), config)
 
-    errors.extend(ensure_hypothesis_is_valid(experiment))
+    v.extend_errors(ensure_hypothesis_is_valid(experiment))
 
     method = experiment.get("method")
     if not method:
-        errors.append(InvalidExperiment("an experiment requires a method with "
-                                        "at least one activity"))
+        v.add_error(
+            "method",
+            "an experiment requires a method with at least one activity")
     else:
         for activity in method:
-            errors.extend(ensure_activity_is_valid(activity))
+            v.extend_errors(ensure_activity_is_valid(activity))
 
             # let's see if a ref is indeed found in the experiment
             ref = activity.get("ref")
             if ref and not lookup_activity(ref):
-                errors.append(
-                    InvalidActivity("referenced activity '{r}' could not be "
-                                    "found in the experiment".format(r=ref)))
+                v.add_error(
+                    "ref",
+                    "referenced activity '{r}' could not be "
+                    "found in the experiment".format(r=ref),
+                    value=ref
+                )
 
     rollbacks = experiment.get("rollbacks", [])
     for activity in rollbacks:
-        errors.extend(ensure_activity_is_valid(activity))
+        v.extend_errors(ensure_activity_is_valid(activity))
 
     warn_about_deprecated_features(experiment)
 
-    errors.extend(validate_controls(experiment))
+    v.extend_errors(validate_controls(experiment))
 
-    if errors:
-        raise ValidationError(full_validation_msg, errors)
+    if v.has_errors():
+        if no_raise:
+            return v.errors()
+        raise InvalidExperiment(full_validation_msg.format(str(v)))
 
     logger.info("Experiment looks valid")
 

--- a/chaoslib/experiment.py
+++ b/chaoslib/experiment.py
@@ -48,54 +48,66 @@ def ensure_experiment_is_valid(experiment: Experiment):
     another set of of  ̀close` probes to sense the state of the system
     post-action.
 
-    This function raises :exc:`InvalidExperiment`, :exc:`InvalidProbe` or
-    :exc:`InvalidAction` depending on where it fails.
+    This function raises an :exc:`InvalidExperiment` error
+    if the experiment is not valid.
+    If multiple validation errors are found, the errors are listed
+    as part of the exception message
     """
     logger.info("Validating the experiment's syntax")
+
+    errors = []
 
     if not experiment:
         raise InvalidExperiment("an empty experiment is not an experiment")
 
     if not experiment.get("title"):
-        raise InvalidExperiment("experiment requires a title")
+        errors.append(InvalidExperiment("experiment requires a title"))
 
     if not experiment.get("description"):
-        raise InvalidExperiment("experiment requires a description")
+        errors.append(InvalidExperiment("experiment requires a description"))
 
     tags = experiment.get("tags")
     if tags:
         if list(filter(lambda t: t == '' or not isinstance(t, str), tags)):
-            raise InvalidExperiment(
-                "experiment tags must be a non-empty string")
+            errors.append(InvalidExperiment(
+                "experiment tags must be a non-empty string"))
 
-    validate_extensions(experiment)
+    errors.extend(validate_extensions(experiment))
 
     config = load_configuration(experiment.get("configuration", {}))
     load_secrets(experiment.get("secrets", {}), config)
 
-    ensure_hypothesis_is_valid(experiment)
+    errors.extend(ensure_hypothesis_is_valid(experiment))
 
     method = experiment.get("method")
     if not method:
-        raise InvalidExperiment("an experiment requires a method with "
-                                "at least one activity")
+        errors.append(InvalidExperiment("an experiment requires a method with "
+                                        "at least one activity"))
+    else:
+        for activity in method:
+            errors.extend(ensure_activity_is_valid(activity))
 
-    for activity in method:
-        ensure_activity_is_valid(activity)
-
-        # let's see if a ref is indeed found in the experiment
-        ref = activity.get("ref")
-        if ref and not lookup_activity(ref):
-            raise InvalidActivity("referenced activity '{r}' could not be "
-                                  "found in the experiment".format(r=ref))
+            # let's see if a ref is indeed found in the experiment
+            ref = activity.get("ref")
+            if ref and not lookup_activity(ref):
+                errors.append(
+                    InvalidActivity("referenced activity '{r}' could not be "
+                                    "found in the experiment".format(r=ref)))
 
     rollbacks = experiment.get("rollbacks", [])
     for activity in rollbacks:
-        ensure_activity_is_valid(activity)
+        errors.extend(ensure_activity_is_valid(activity))
 
     warn_about_deprecated_features(experiment)
 
-    validate_controls(experiment)
+    errors.extend(validate_controls(experiment))
+
+    if errors:
+        full_validation_msg = 'Experiment is not valid, ' \
+                              'please fix the following errors:'
+        for error in errors:
+            full_validation_msg += '\n- {}'.format(error)
+        raise InvalidExperiment(full_validation_msg)
 
     logger.info("Experiment looks valid")
 

--- a/chaoslib/extension.py
+++ b/chaoslib/extension.py
@@ -1,25 +1,29 @@
 # -*- coding: utf-8 -*-
-from typing import Optional
+from typing import Optional, List
 
-from chaoslib.exceptions import InvalidExperiment
+from chaoslib.exceptions import InvalidExperiment, ChaosException
 from chaoslib.types import Experiment, Extension
 
 __all__ = ["get_extension", "has_extension", "set_extension",
            "merge_extension", "remove_extension", "validate_extensions"]
 
 
-def validate_extensions(experiment: Experiment):
+def validate_extensions(experiment: Experiment) -> List[ChaosException]:
     """
     Validate that extensions respect the specification.
     """
     extensions = experiment.get("extensions")
     if not extensions:
-        return
+        return []
 
+    errors = []
     for ext in extensions:
         ext_name = ext.get('name')
         if not ext_name or not ext_name.strip():
-            raise InvalidExperiment("All extensions require a non-empty name")
+            errors.append(
+                InvalidExperiment("All extensions require a non-empty name"))
+
+    return errors
 
 
 def get_extension(experiment: Experiment, name: str) -> Optional[Extension]:

--- a/chaoslib/extension.py
+++ b/chaoslib/extension.py
@@ -2,13 +2,14 @@
 from typing import Optional, List
 
 from chaoslib.exceptions import InvalidExperiment, ChaosException
-from chaoslib.types import Experiment, Extension
+from chaoslib.types import Experiment, Extension, ValidationError
+from chaoslib.validation import Validation
 
 __all__ = ["get_extension", "has_extension", "set_extension",
            "merge_extension", "remove_extension", "validate_extensions"]
 
 
-def validate_extensions(experiment: Experiment) -> List[ChaosException]:
+def validate_extensions(experiment: Experiment) -> List[ValidationError]:
     """
     Validate that extensions respect the specification.
     """
@@ -16,14 +17,15 @@ def validate_extensions(experiment: Experiment) -> List[ChaosException]:
     if not extensions:
         return []
 
-    errors = []
+    v = Validation()
     for ext in extensions:
         ext_name = ext.get('name')
         if not ext_name or not ext_name.strip():
-            errors.append(
-                InvalidExperiment("All extensions require a non-empty name"))
+            v.add_error(
+                "extensions", "All extensions require a non-empty name")
+            break
 
-    return errors
+    return v.errors()
 
 
 def get_extension(experiment: Experiment, name: str) -> Optional[Extension]:

--- a/chaoslib/hypothesis.py
+++ b/chaoslib/hypothesis.py
@@ -34,21 +34,25 @@ def ensure_hypothesis_is_valid(experiment: Experiment):
     """
     hypo = experiment.get("steady-state-hypothesis")
     if hypo is None:
-        return
+        return []
 
+    errors = []
     if not hypo.get("title"):
-        raise InvalidExperiment("hypothesis requires a title")
+        errors.append(InvalidExperiment("hypothesis requires a title"))
 
     probes = hypo.get("probes")
     if probes:
         for probe in probes:
-            ensure_activity_is_valid(probe)
+            errors.extend(ensure_activity_is_valid(probe))
 
             if "tolerance" not in probe:
-                raise InvalidActivity(
-                    "hypothesis probe must have a tolerance entry")
+                errors.append(InvalidActivity(
+                    "hypothesis probe must have a tolerance entry"))
+            else:
+                errors.extend(
+                    ensure_hypothesis_tolerance_is_valid(probe["tolerance"]))
 
-            ensure_hypothesis_tolerance_is_valid(probe["tolerance"])
+    return errors
 
 
 def ensure_hypothesis_tolerance_is_valid(tolerance: Tolerance):
@@ -80,6 +84,9 @@ def ensure_hypothesis_tolerance_is_valid(tolerance: Tolerance):
             raise InvalidActivity(
                 "hypothesis probe tolerance type '{}' is unsupported".format(
                     tolerance_type))
+
+    # TODO
+    return []
 
 
 def check_regex_pattern(tolerance: Tolerance):

--- a/chaoslib/provider/http.py
+++ b/chaoslib/provider/http.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-from typing import Any
+from typing import Any, List
 import urllib3
 
 from logzero import logger
 import requests
 
 from chaoslib import substitute
-from chaoslib.exceptions import ActivityFailed, InvalidActivity
+from chaoslib.exceptions import ActivityFailed, InvalidActivity, ChaosException
 from chaoslib.types import Activity, Configuration, Secrets
 
 
@@ -89,7 +89,7 @@ def run_http_activity(activity: Activity, configuration: Configuration,
         raise ActivityFailed("activity took too long to complete")
 
 
-def validate_http_activity(activity: Activity):
+def validate_http_activity(activity: Activity) -> List[ChaosException]:
     """
     Validate a HTTP activity.
 
@@ -102,15 +102,20 @@ def validate_http_activity(activity: Activity):
     * `"method"` which is the HTTP verb to use (default to `"GET"`)
     * `"headers"` which must be a mapping of string to string
 
-    In all failing cases, raises :exc:`InvalidActivity`.
+    In all failing cases, returns a list of errors.
 
     This should be considered as a private function.
     """
+    errors = []
+
     provider = activity["provider"]
     url = provider.get("url")
     if not url:
-        raise InvalidActivity("a HTTP activity must have a URL")
+        errors.append(InvalidActivity("a HTTP activity must have a URL"))
 
     headers = provider.get("headers")
     if headers and not type(headers) == dict:
-        raise InvalidActivity("a HTTP activities expect headers as a mapping")
+        errors.append(
+            InvalidActivity("a HTTP activities expect headers as a mapping"))
+
+    return errors

--- a/chaoslib/provider/http.py
+++ b/chaoslib/provider/http.py
@@ -7,7 +7,8 @@ import requests
 
 from chaoslib import substitute
 from chaoslib.exceptions import ActivityFailed, InvalidActivity, ChaosException
-from chaoslib.types import Activity, Configuration, Secrets
+from chaoslib.types import Activity, Configuration, Secrets, ValidationError
+from chaoslib.validation import Validation
 
 
 __all__ = ["run_http_activity", "validate_http_activity"]
@@ -89,7 +90,7 @@ def run_http_activity(activity: Activity, configuration: Configuration,
         raise ActivityFailed("activity took too long to complete")
 
 
-def validate_http_activity(activity: Activity) -> List[ChaosException]:
+def validate_http_activity(activity: Activity) -> List[ValidationError]:
     """
     Validate a HTTP activity.
 
@@ -106,16 +107,15 @@ def validate_http_activity(activity: Activity) -> List[ChaosException]:
 
     This should be considered as a private function.
     """
-    errors = []
+    v = Validation()
 
     provider = activity["provider"]
     url = provider.get("url")
     if not url:
-        errors.append(InvalidActivity("a HTTP activity must have a URL"))
+        v.add_error("url", "a HTTP activity must have a URL")
 
     headers = provider.get("headers")
     if headers and not type(headers) == dict:
-        errors.append(
-            InvalidActivity("a HTTP activities expect headers as a mapping"))
+        v.add_error("headers", "a HTTP activities expect headers as a mapping")
 
-    return errors
+    return v.errors()

--- a/chaoslib/provider/python.py
+++ b/chaoslib/provider/python.py
@@ -9,7 +9,8 @@ from logzero import logger
 
 from chaoslib import substitute
 from chaoslib.exceptions import ActivityFailed, InvalidActivity, ChaosException
-from chaoslib.types import Activity, Configuration, Secrets
+from chaoslib.types import Activity, Configuration, Secrets, ValidationError
+from chaoslib.validation import Validation
 
 
 __all__ = ["run_python_activity", "validate_python_activity"]
@@ -60,7 +61,7 @@ def run_python_activity(activity: Activity, configuration: Configuration,
                     sys.exc_info()[2])
 
 
-def validate_python_activity(activity: Activity) -> List[ChaosException]:
+def validate_python_activity(activity: Activity) -> List[ValidationError]:
     """
     Validate a Python activity.
 
@@ -76,33 +77,31 @@ def validate_python_activity(activity: Activity) -> List[ChaosException]:
 
     This should be considered as a private function.
     """
-    errors = []
+    v = Validation()
 
     name = activity.get("name")
     provider = activity.get("provider")
     mod_name = provider.get("module")
     if not mod_name:
-        errors.append(
-            InvalidActivity("a Python activity must have a module path"))
+        v.add_error("module", "a Python activity must have a module path")
 
     func = provider.get("func")
     if not func:
-        errors.append(
-            InvalidActivity("a Python activity must have a function name"))
+        v.add_error("func", "a Python activity must have a function name")
 
     if not mod_name or not func:
         # no module no function, we cannot do anymore validation
-        return errors
+        return v.errors()
 
     try:
         mod = importlib.import_module(mod_name)
     except ImportError:
-        errors.append(
-            InvalidActivity("could not find Python module '{mod}' "
-                            "in activity '{name}'".format(
-                                mod=mod_name, name=name)))
+        msg = "could not find Python module '{mod}' in activity '{name}'"\
+            .format(mod=mod_name, name=name)
+        v.add_error("module", msg, value=mod_name)
+
         # module is not imported, we cannot do any more validation
-        return errors
+        return v.errors()
 
     found_func = False
     arguments = provider.get("arguments", {})
@@ -137,23 +136,30 @@ def validate_python_activity(activity: Activity) -> List[ChaosException]:
                 msg = str(x)
                 if "missing" in msg:
                     arg = msg.rsplit(":", 1)[1].strip()
-                    errors.append(InvalidActivity(
+                    v.add_error(
+                        "arguments",
                         "required argument {arg} is missing from "
-                        "activity '{name}'".format(arg=arg, name=name)))
+                        "activity '{name}'".format(arg=arg, name=name),
+                    )
                 elif "unexpected" in msg:
                     arg = msg.rsplit(" ", 1)[1].strip()
-                    errors.append(InvalidActivity(
+                    v.add_error(
+                        "arguments",
                         "argument {arg} is not part of the "
                         "function signature in activity '{name}'".format(
-                            arg=arg, name=name)))
+                            arg=arg, name=name)
+                    )
                 else:
                     # another error? let's fail fast
                     raise
             break
 
     if not found_func:
-        errors.append(InvalidActivity(
+        v.add_error(
+            "func",
             "'{mod}' does not expose '{func}' in activity '{name}'".format(
-                mod=mod_name, func=func, name=name)))
+                mod=mod_name, func=func, name=name),
+            value=func
+        )
 
-    return errors
+    return v.errors()

--- a/chaoslib/types.py
+++ b/chaoslib/types.py
@@ -5,7 +5,7 @@ __all__ = ["MicroservicesStatus", "Probe", "Action", "Experiment", "Layer",
            "TargetLayers", "Activity", "Journal", "Run", "Secrets", "Step",
            "Configuration", "Discovery", "DiscoveredActivities", "Extension",
            "DiscoveredSystemInfo", "Settings", "EventPayload", "Tolerance",
-           "Hypothesis", "Control"]
+           "Hypothesis", "Control", "ValidationError"]
 
 
 Action = Dict[str, Any]
@@ -37,3 +37,5 @@ Tolerance = Union[int, str, bool, list, Dict[str, Any]]
 Extension = Dict[str, Any]
 Hypothesis = Dict[str, Any]
 Control = Dict[str, Any]
+
+ValidationError = Dict[str, Any]

--- a/chaoslib/validation.py
+++ b/chaoslib/validation.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+import json
+from typing import List, Dict, Any, Union
+
+from chaoslib.types import ValidationError
+
+__all__ = ["Validation"]
+
+
+class Validation(object):
+    """
+    This class keeps a list of validation errors to be appended
+    to report all errors at once
+    """
+    def __init__(self):
+        self._errors = []  # type: List[ValidationError]
+
+    def add_error(self, field: str, message: str,
+                  value: Any = None, location: tuple = None):
+        """
+        Append a new error to the validation errors list
+
+        :param field: name of the key/field that raised the validation error
+        :param message: information about the error
+        :param value: value being validated - that failed -
+        :param location: optional location of the key in the full document
+            as a json-path-like; e.g. ("rollbacks", 0, "type")
+            NB: For list/tuples, the index of the failed sub-element is used
+        """
+        if location is None:
+            location = ()
+
+        self._errors.append(
+            {
+                "field": field,
+                "msg": message,
+                "value": value,
+                "loc": location,
+            }
+        )
+
+    def has_errors(self) -> bool:
+        return len(self.errors())
+
+    def extend_errors(self, errors: List[ValidationError]):
+        self._errors.extend(errors)
+
+    def merge(self, val: 'Validation'):
+        self.extend_errors(val.errors())
+
+    def errors(self) -> List[ValidationError]:
+        return self._errors
+
+    def json(self, indent: Union[None, int, str] = 2) -> str:
+        return json.dumps(self.errors(), indent=indent)
+
+    def display_errors(self):
+        return _display_errors(self.errors())
+
+    def __str__(self) -> str:
+        errors = self.errors()
+        nb_errors = len(errors)
+        return (
+            "{count} validation error{plural}\n"
+            "{errors}".format(
+                count=nb_errors, plural="" if nb_errors == 1 else "s",
+                errors=_display_errors(errors)
+            )
+        )
+
+
+def _display_errors(errors: List[ValidationError]) -> str:
+    error_format = "{field}\n\t{msg} -> {loc} ({val})"
+    return '\n'.join(error_format.format(
+        field=e["field"], msg=e["msg"], val=e["value"],
+        loc=_display_error_loc(e)) for e in errors)
+
+
+def _display_error_loc(error: ValidationError) -> str:
+    return '.'.join(str(l) for l in error['loc'])

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -12,6 +12,6 @@ from fixtures import actions
 
 
 def test_empty_action_is_invalid():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(actions.EmptyAction)
-    assert "empty activity is no activity" in str(exc.value)
+    errors = ensure_activity_is_valid(actions.EmptyAction)
+    assert "empty activity is no activity" in str(errors[0])
+

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -232,13 +232,14 @@ def test_validate_python_control_must_be_loadable(logger):
 
 
 def test_validate_python_control_needs_a_module():
-    with pytest.raises(InvalidActivity):
-        validate_python_control({
+    errors = validate_python_control({
             "name": "a-python-control",
             "provider": {
                 "type": "python"
             }
         })
+    assert len(errors)
+    assert type(errors[0]) == InvalidActivity
 
 
 def test_controls_can_access_experiment():

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -239,7 +239,6 @@ def test_validate_python_control_needs_a_module():
             }
         })
     assert len(errors)
-    assert type(errors[0]) == InvalidActivity
 
 
 def test_controls_can_access_experiment():

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -102,7 +102,7 @@ def test_experiment_hypothesis_must_have_a_title():
 
 
 def test_experiment_hypothesis_must_have_a_valid_probe():
-    with pytest.raises(InvalidActivity) as exc:
+    with pytest.raises(InvalidExperiment) as exc:
         ensure_experiment_is_valid(experiments.ExperimentWithInvalidHypoProbe)
     assert "required argument 'path' is missing from activity" in str(exc.value)
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -9,10 +9,10 @@ from fixtures import experiments
 
 
 def test_extensions_must_have_name():
-    with pytest.raises(InvalidExperiment):
-        exp = experiments.Experiment.copy()
-        set_extension(exp, {"somekey": "blah"})
-        validate_extensions(exp)
+    exp = experiments.Experiment.copy()
+    set_extension(exp, {"somekey": "blah"})
+    errors = validate_extensions(exp)
+    assert len(errors)
 
 
 def test_get_extension_returns_nothing_when_not_extensions_block():

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -14,77 +14,83 @@ from chaoslib.activity import ensure_activity_is_valid, run_activity
 from fixtures import config, experiments, probes
 
 
+def assert_in_errors(msg, errors):
+    """
+    Check whether msg can be found in any of the list of errors
+
+    :param msg: exception string to be found in any of the instances
+    :param errors: list of ChaosException instances
+    """
+    for error in errors:
+        if msg in str(error):
+            # expected exception message is found
+            return
+
+    raise AssertionError("{} not in {}".format(msg, errors))
+
+
 def test_empty_probe_is_invalid():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.EmptyProbe)
-    assert "empty activity is no activity" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.EmptyProbe)
+    assert_in_errors("empty activity is no activity", errors)
 
 
 def test_probe_must_have_a_type():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.MissingTypeProbe)
-    assert "an activity must have a type" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.MissingTypeProbe)
+    assert_in_errors("an activity must have a type", errors)
 
 
 def test_probe_must_have_a_known_type():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.UnknownTypeProbe)
-    assert "'whatever' is not a supported activity type" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.UnknownTypeProbe)
+    assert_in_errors("'whatever' is not a supported activity type", errors)
 
 
 def test_probe_provider_must_have_a_known_type():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.UnknownProviderTypeProbe)
-    assert "unknown provider type 'pizza'" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.UnknownProviderTypeProbe)
+    assert_in_errors("unknown provider type 'pizza'", errors)
 
 
 def test_python_probe_must_have_a_module_path():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.MissingModuleProbe)
-    assert "a Python activity must have a module path" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.MissingModuleProbe)
+    assert_in_errors("a Python activity must have a module path", errors)
 
 
 def test_python_probe_must_have_a_function_name():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.MissingFunctionProbe)
-    assert "a Python activity must have a function name" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.MissingFunctionProbe)
+    assert_in_errors("a Python activity must have a function name", errors)
 
 
 def test_python_probe_must_be_importable():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.NotImportableModuleProbe)
-    assert "could not find Python module 'fake.module'" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.NotImportableModuleProbe)
+    assert_in_errors("could not find Python module 'fake.module'", errors)
 
 
 def test_python_probe_func_must_have_enough_args():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.MissingFuncArgProbe)
-    assert "required argument 'path' is missing" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.MissingFuncArgProbe)
+    assert_in_errors("required argument 'path' is missing", errors)
 
 
 def test_python_probe_func_cannot_have_too_many_args():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.TooManyFuncArgsProbe)
-    assert "argument 'should_not_be_here' is not part of the " \
-           "function signature" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.TooManyFuncArgsProbe)
+    assert_in_errors(
+        "argument 'should_not_be_here' is not part of the function signature",
+        errors)
 
 
 def test_process_probe_have_a_path():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.MissingProcessPathProbe)
-    assert "a process activity must have a path" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.MissingProcessPathProbe)
+    assert_in_errors("a process activity must have a path", errors)
 
 
 def test_process_probe_path_must_exist():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.ProcessPathDoesNotExistProbe)
-    assert "path 'None' cannot be found, in activity" in str(exc.value)
+    print(probes.ProcessPathDoesNotExistProbe)
+    errors = ensure_activity_is_valid(probes.ProcessPathDoesNotExistProbe)
+    print(errors)
+    assert_in_errors("path 'None' cannot be found, in activity", errors)
 
 
 def test_http_probe_must_have_a_url():
-    with pytest.raises(InvalidActivity) as exc:
-        ensure_activity_is_valid(probes.MissingHTTPUrlProbe)
-    assert "a HTTP activity must have a URL" in str(exc.value)
+    errors = ensure_activity_is_valid(probes.MissingHTTPUrlProbe)
+    assert_in_errors("a HTTP activity must have a URL", errors)
 
 
 def test_run_python_probe_should_return_raw_value():

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -12,21 +12,7 @@ from chaoslib.exceptions import ActivityFailed, InvalidActivity
 from chaoslib.activity import ensure_activity_is_valid, run_activity
 
 from fixtures import config, experiments, probes
-
-
-def assert_in_errors(msg, errors):
-    """
-    Check whether msg can be found in any of the list of errors
-
-    :param msg: exception string to be found in any of the instances
-    :param errors: list of ChaosException instances
-    """
-    for error in errors:
-        if msg in str(error):
-            # expected exception message is found
-            return
-
-    raise AssertionError("{} not in {}".format(msg, errors))
+from test_validation import assert_in_errors
 
 
 def test_empty_probe_is_invalid():
@@ -82,10 +68,8 @@ def test_process_probe_have_a_path():
 
 
 def test_process_probe_path_must_exist():
-    print(probes.ProcessPathDoesNotExistProbe)
     errors = ensure_activity_is_valid(probes.ProcessPathDoesNotExistProbe)
-    print(errors)
-    assert_in_errors("path 'None' cannot be found, in activity", errors)
+    assert_in_errors("path 'somewhere/not/here' cannot be found, in activity", errors)
 
 
 def test_http_probe_must_have_a_url():

--- a/tests/test_tolerance.py
+++ b/tests/test_tolerance.py
@@ -7,6 +7,9 @@ from chaoslib.hypothesis import ensure_hypothesis_tolerance_is_valid, \
     within_tolerance
 
 
+from test_validation import assert_in_errors
+
+
 def test_tolerance_int():
     assert within_tolerance(6, value=6) is True
 
@@ -266,8 +269,8 @@ def test_tolerance_jsonpath_cannot_be_empty():
         "path": ""
     }
 
-    with pytest.raises(InvalidActivity):
-        ensure_hypothesis_tolerance_is_valid(t)
+    errors = ensure_hypothesis_tolerance_is_valid(t)
+    assert len(errors)
 
 
 def test_tolerance_regex_stdout_process():
@@ -373,40 +376,36 @@ def test_tolerance_regex_body_http():
 
 
 def test_tolerance_regex_must_have_a_pattern():
-    with pytest.raises(InvalidActivity) as e:
-        ensure_hypothesis_tolerance_is_valid({
+    errors = ensure_hypothesis_tolerance_is_valid({
             "type": "regex",
             "target": "stdout"
         })
-    assert "tolerance must have a `pattern` key" in str(e.value)
+    assert_in_errors("tolerance must have a `pattern` key", errors)
 
 
 def test_tolerance_regex_must_have_a_valid_pattern_type():
-    with pytest.raises(InvalidActivity) as e:
-        ensure_hypothesis_tolerance_is_valid({
+    errors = ensure_hypothesis_tolerance_is_valid({
             "type": "regex",
             "target": "stdout",
             "pattern": None
         })
-    assert "tolerance pattern None has an invalid type" in str(e.value)
+    assert_in_errors("tolerance pattern None has an invalid type", errors)
 
 
 def test_tolerance_regex_must_have_a_valid_pattern():
-    with pytest.raises(InvalidActivity) as e:
-        ensure_hypothesis_tolerance_is_valid({
+    errors = ensure_hypothesis_tolerance_is_valid({
             "type": "regex",
             "target": "stdout",
             "pattern": "[0-9"
         })
-    assert "pattern [0-9 seems invalid" in str(e.value)
+    assert_in_errors("pattern [0-9 seems invalid", errors)
 
 
 def test_tolerance_unsupported_type():
-    with pytest.raises(InvalidActivity) as e:
-        ensure_hypothesis_tolerance_is_valid({
+    errors = ensure_hypothesis_tolerance_is_valid({
             "type": "boom"
         })
-    assert "tolerance type 'boom' is unsupported" in str(e.value)
+    assert_in_errors("tolerance type 'boom' is unsupported", errors)
 
 
 def test_tolerance_missing_jsonpath_backend():
@@ -517,8 +516,8 @@ def test_tolerance_range_lower_boundary_must_be_a_number():
         "target": "body",
         "range": ["a", 6]
     }
-    with pytest.raises(InvalidActivity):
-        ensure_hypothesis_tolerance_is_valid(t)
+    errors = ensure_hypothesis_tolerance_is_valid(t)
+    assert len(errors)
 
 
 def test_tolerance_range_upper_boundary_must_be_a_number():
@@ -527,8 +526,8 @@ def test_tolerance_range_upper_boundary_must_be_a_number():
         "target": "body",
         "range": [6, "b"]
     }
-    with pytest.raises(InvalidActivity):
-        ensure_hypothesis_tolerance_is_valid(t)
+    errors = ensure_hypothesis_tolerance_is_valid(t)
+    assert len(errors)
 
 
 def test_tolerance_range_checked_value_must_be_a_number():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from chaoslib.validation import Validation
+
+
+def assert_in_errors(msg, errors):
+    """
+    Check whether msg can be found in any of the list of errors
+
+    :param msg: exception string to be found in any of the instances
+    :param errors: list of ChaosException instances
+    """
+    print(errors)
+    for error in errors:
+        if msg in error["msg"]:
+            # expected exception message is found
+            return
+
+    raise AssertionError("{} not in {}".format(msg, errors))
+
+
+#
+# v = Validation()
+# v.add_error("key", "invalid value", value=5, location=("test", 0, "key"))
+# v.add_error("other", "missing required value", value=None, location=("name",))
+# v.add_error("dummy", "this is an error")
+# from logzero import logger
+# logger.debug('Experiment is invalid. \n{errors}'.format(errors=str(v)))
+# # print(v)
+
+def test_add_error():
+    v = Validation()
+    v.add_error("test", "this is an error message")
+    assert v.has_errors()
+
+
+def test_extend_errors():
+    v = Validation()
+    v.add_error("test", "this is an error message")
+    v.extend_errors([{'dummy': 'error'}, {'another': 'error'}])
+    assert len(v.errors()) == 3
+
+
+def test_display_errors():
+    v = Validation()
+    v.add_error("test", "this is an error message", value=False,
+                location=("a", "b", "c"))
+    str = v.display_errors()
+    assert len(str)
+
+
+def test_errors_as_json():
+    v = Validation()
+    v.add_error("test", "this is an error message", value=False,
+                location=("a", "b", "c"))
+    json = v.json()
+    assert len(json)
+
+
+def test_merge_validation():
+    v1 = Validation()
+    v1.add_error("test", "this is an error message")
+
+    v2 = Validation()
+    v2.add_error("test", "this is another error message")
+
+    v1.merge(v2)
+    assert len(v1.errors()) == 2
+
+
+def test_str_output():
+    v = Validation()
+    v.add_error("test", "this is an error message", value=False,
+                location=("a", "b", "c"))
+    assert str(v)


### PR DESCRIPTION
@Lawouach 

this is similar purpose as the previous PR, to validate all experiment file syntax and report all at once. This internal is though different.

This is mode advanced refactoring, that would be useful to display more information to the user than the error string. We could output the message, the field in error, the value being validated, as well as a path/location within the object structure.

This is done internally by Validation objects that shall be created by all validation functions, to append errors with all possible arguments, and return the list of errors. An error is now a dict with defined structure.

This PR is intended to be reviewed and chosen between the other one https://github.com/chaostoolkit/chaostoolkit-lib/pull/155, before we continue any further

still to be done, is to add the path/location of each error. 