### PR TITLE
Allow interpolation of title

### DIFF
--- a/chaoslib/experiment.py
+++ b/chaoslib/experiment.py
@@ -7,7 +7,7 @@ from typing import List
 
 from logzero import logger
 
-from chaoslib import __version__
+from chaoslib import __version__, substitute
 from chaoslib.activity import ensure_activity_is_valid, run_activities
 from chaoslib.caching import with_cache, lookup_activity
 from chaoslib.control import initialize_controls, controls, cleanup_controls, \
@@ -179,8 +179,6 @@ def run_experiment(experiment: Experiment,
     interrupted, we set the `interrupted` flag of the result accordingly to
     notify the caller this was indeed not terminated properly.
     """
-    logger.info("Running experiment: {t}".format(t=experiment["title"]))
-
     dry = experiment.get("dry", False)
     if dry:
         logger.warning("Dry mode enabled")
@@ -192,6 +190,9 @@ def run_experiment(experiment: Experiment,
     initialize_global_controls(experiment, config, secrets, settings)
     initialize_controls(experiment, config, secrets)
     activity_pool, rollback_pool = get_background_pools(experiment)
+
+    experiment["title"] = substitute(experiment["title"], config, secrets)
+    logger.info("Running experiment: {t}".format(t=experiment["title"]))
 
     control = Control()
     journal = initialize_run_journal(experiment)

--- a/tests/fixtures/experiments.py
+++ b/tests/fixtures/experiments.py
@@ -74,6 +74,31 @@ ExperimentWithInvalidHypoProbe = {
     ]
 }
 
+ExperimentWithInterpolatedTitle = {
+    "configuration": {
+        "project_name": {
+            "type": "env",
+            "key": "PROJECT_NAME",
+            "default": "Cats in space"
+        }
+    },
+    "dry_run": True,
+    "title": "${project_name}: do cats live in the Internet?",
+    "description": "an experiment of importance",
+    "steady-state-hypothesis": {
+        "title": "hello",
+        "probes": [
+            PythonModuleProbeWithBoolTolerance,
+        ]
+    },
+    "method": [
+        PythonModuleProbe,
+        {
+            "ref": PythonModuleProbe["name"]
+        }
+    ]
+}
+
 ExperimentWithLongPause = {
     "title": "do cats live in the Internet?",
     "description": "an experiment of importance",

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -80,6 +80,12 @@ def test_experiment_must_have_a_title():
     assert "experiment requires a title" in str(exc.value)
 
 
+def test_experiment_title_substitution():
+    journal = run_experiment(experiments.ExperimentWithInterpolatedTitle)
+
+    assert journal["experiment"]["title"] in "Cats in space: do cats live in the Internet?"
+
+
 def test_experiment_must_have_a_description():
     with pytest.raises(InvalidExperiment) as exc:
         ensure_experiment_is_valid(experiments.MissingDescriptionExperiment)
@@ -261,6 +267,7 @@ def test_should_bail_experiment_when_env_was_not_found():
         run_experiment(experiment)
     assert "Configuration makes reference to an environment key that does " \
            "not exist" in str(x.value)
+
 
 def test_validate_all_tolerance_probes():
     with requests_mock.mock() as m:


### PR DESCRIPTION
Use case: I like having generic, re-usable experiments for different services. Configuration currently does a great job doing that, but I'd love the title to include my service name too.