### PR TITLE
Pass all secrets to all control points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.12.0...HEAD
 
+### Changed
+
+- Always pass all secrets to control hookpoints [#187][187]
+
+[187]: https://github.com/chaostoolkit/chaostoolkit/issues/187
+
 ## [1.12.0][] - 2020-08-17
 
 [1.12.0]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.11.1...1.12.0

--- a/chaoslib/control/python.py
+++ b/chaoslib/control/python.py
@@ -124,10 +124,9 @@ def apply_python_control(level: str, control: Control,  # noqa: C901
         arguments = substitute(arguments, configuration, secrets)
 
     sig = inspect.signature(func)
-    if "secrets" in provider and "secrets" in sig.parameters:
-        arguments["secrets"] = {}
-        for s in provider["secrets"]:
-            arguments["secrets"].update(secrets.get(s, {}))
+
+    if "secrets" in sig.parameters:
+        arguments["secrets"] = secrets
 
     if "configuration" in sig.parameters:
         arguments["configuration"] = configuration

--- a/tests/fixtures/controls/dummy_with_secrets.py
+++ b/tests/fixtures/controls/dummy_with_secrets.py
@@ -1,0 +1,54 @@
+from typing import Any, Dict, List
+
+from chaoslib.types import Activity, Configuration, \
+    Experiment, Hypothesis, Journal, Run, Secrets, Settings
+
+
+def configure_control(experiment: Experiment, configuration: Configuration,
+                      secrets: Secrets, settings: Settings):
+    experiment["configure_control_secrets"] = secrets
+
+
+def cleanup_control():
+    pass
+
+
+def before_experiment_control(context: Experiment, secrets: Secrets, **kwargs):
+    context["before_experiment_control_secrets"] = secrets
+
+
+def after_experiment_control(context: Experiment, state: Journal, secrets: Secrets, **kwargs):
+    context["after_experiment_control_secrets"] = secrets
+
+
+def before_hypothesis_control(context: Hypothesis, experiment: Experiment, secrets: Secrets, **kwargs):
+    experiment["before_hypothesis_control_secrets"] = secrets
+
+
+def after_hypothesis_control(context: Hypothesis, experiment: Experiment,
+                             state: Dict[str, Any], secrets: Secrets, **kwargs):
+    experiment["after_hypothesis_control_secrets"] = secrets
+
+
+def before_method_control(context: Experiment, secrets: Secrets, **kwargs):
+    context["before_method_control_secrets"] = secrets
+
+
+def after_method_control(context: Experiment, state: List[Run], secrets: Secrets, **kwargs):
+    context["after_method_control_secrets"] = secrets
+
+
+def before_rollback_control(context: Experiment, secrets: Secrets, **kwargs):
+    context["before_rollback_control_secrets"] = secrets
+
+
+def after_rollback_control(context: Experiment, state: List[Run], secrets: Secrets, **kwargs):
+    context["after_rollback_control_secrets"] = secrets
+
+
+def before_activity_control(context: Activity, experiment: Experiment, secrets: Secrets, **kwargs):
+    experiment["before_activity_control_secrets"] = secrets
+
+
+def after_activity_control(context: Activity, experiment: Experiment, state: Run, secrets: Secrets, **kwargs):
+    experiment["after_activity_control_secrets"] = secrets

--- a/tests/fixtures/experiments.py
+++ b/tests/fixtures/experiments.py
@@ -310,6 +310,15 @@ ExperimentWithControls["controls"] = [
     }
 ]
 
+ExperimentWithControlsRequiringSecrets = deepcopy(ExperimentWithControls)
+ExperimentWithControlsRequiringSecrets["secrets"] = {
+    "mystuff": {
+        "somesecret": "somevalue"
+    }
+}
+ExperimentWithControlsRequiringSecrets["controls"][0]["provider"]["module"] = "fixtures.controls.dummy_with_secrets"
+ExperimentWithControlsRequiringSecrets["controls"][0]["provider"]["secrets"] = ["mystuff"]
+
 ExperimentWithControlsThatUpdatedConfiguration = deepcopy(ExperimentNoControls)
 ExperimentWithControlsThatUpdatedConfiguration["configuration"] = {
     "my_token": "UNSET"

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -558,15 +558,25 @@ def test_controls_on_loaded_experiment():
 
 def test_control_can_update_configuration():
     exp = deepcopy(experiments.ExperimentWithControlsThatUpdatedConfiguration)
-    with controls("experiment", exp, context=exp):
-        state = run_experiment(exp)
-
+    state = run_experiment(exp)
     assert state["run"][0]["output"] != "UNSET"
 
 
 def test_control_can_update_secrets():
     exp = deepcopy(experiments.ExperimentWithControlsThatUpdatedSecrets)
-    with controls("experiment", exp, context=exp):
-        state = run_experiment(exp)
-
+    state = run_experiment(exp)
     assert state["run"][0]["output"] != "UNSET"
+
+
+def test_secrets_are_passed_to_all_control_hookpoints():
+    exp = deepcopy(experiments.ExperimentWithControlsRequiringSecrets)
+    run_experiment(exp)
+
+    secrets = exp["secrets"]
+    for hookpoint in ("configure_control", "before_experiment_control",
+            "after_experiment_control", "before_method_control",
+            "after_method_control", "before_rollback_control",
+            "after_rollback_control", "before_hypothesis_control",
+            "after_hypothesis_control", "before_activity_control",
+            "after_activity_control"):
+        assert exp["{}_secrets".format(hookpoint)] == secrets, "{} was not provided the secrets".format(hookpoint)


### PR DESCRIPTION
With this change, the secrets get to be passed to all hook points of controls, all the time, not just when they are declared in the provider like actions/probes.

Closes chaostoolkit/chaostoolkit#187

Signed-off-by: Sylvain Hellegouarch <sh@defuze.org>