### PR TITLE
Resolves issue #209 (allowing nested parsing of secrets)

### DIFF
--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -197,7 +197,7 @@ def test_read_secrets_from_vault_with_kv_version_1(hvac):
     hvac.Client.return_value = fake_client
     fake_client.secrets.kv.v1.read_secret.return_value = vault_secret_payload
 
-    secrets = load_secrets_from_vault(secrets_info, config)
+    secrets = load_secrets(secrets_info, config)
     assert secrets["k8s"]["a-secret"] == {
         "my-important-secret": "bar",
         "my-less-important-secret": "baz"
@@ -213,7 +213,7 @@ def test_read_secrets_from_vault_with_kv_version_1(hvac):
         }
     }
 
-    secrets = load_secrets_from_vault(secrets_info, config)
+    secrets = load_secrets(secrets_info, config)
     assert secrets["k8s"]["a-secret"] == "bar"
 
 
@@ -254,7 +254,7 @@ def test_read_secrets_from_vault_with_kv_version_2(hvac):
     hvac.Client.return_value = fake_client
     fake_client.secrets.kv.v2.read_secret_version.return_value = vault_secret_payload
 
-    secrets = load_secrets_from_vault(secrets_info, config)
+    secrets = load_secrets(secrets_info, config)
     assert secrets["k8s"]["a-secret"] == {
         "my-important-secret": "bar",
         "my-less-important-secret": "baz"
@@ -270,7 +270,7 @@ def test_read_secrets_from_vault_with_kv_version_2(hvac):
         }
     }
 
-    secrets = load_secrets_from_vault(secrets_info, config)
+    secrets = load_secrets(secrets_info, config)
     assert secrets["k8s"]["a-secret"] == "bar"
 
 
@@ -383,7 +383,15 @@ def test_vault_replace_entire_declare(hvac):
     assert secrets["myapp"]["token"] == "bar"
 
 @patch('chaoslib.secret.hvac')
-def test_override_vault_with_var(hvac):
+def test_key_not_in_vault(hvac):
+    pass
+
+@patch('chaoslib.secret.hvac')
+def test_no_vault_entry(hvac):
+    pass
+
+@patch('chaoslib.secret.hvac')
+def test_override_vault_with_vars(hvac):
     config = {
         'vault_addr': 'http://someaddr.com',
         'vault_token': 'not_awesome_token',

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -9,9 +9,8 @@ from chaoslib.secret import load_secrets, load_secrets_from_vault, \
 from fixtures import config
 from unittest.mock import ANY, MagicMock, patch, mock_open
 
-
+@patch.dict(os.environ, {"KUBE_API_URL": "http://1.2.3.4"})
 def test_should_load_environment():
-    os.environ["KUBE_API_URL"] = "http://1.2.3.4"
     secrets = load_secrets({
         "kubernetes": {
             "api_server_url": {
@@ -31,7 +30,7 @@ def test_should_load_inline():
     }, config.EmptyConfig)
     assert secrets["kubernetes"]["api_server_url"] == "http://1.2.3.4"
 
-
+@patch.dict(os.environ, {"KUBE_API_URL": "http://1.2.3.4"})
 def test_should_merge_properly():
     secrets = load_secrets({
         "kubernetes": {
@@ -252,9 +251,8 @@ def test_read_secrets_from_vault_with_kv_version_2(hvac):
     secrets = load_secrets_from_vault(secrets_info, config)
     assert secrets["k8s"]["a-secret"] == "bar"
 
-
+@patch.dict(os.environ, {"KUBE_API_URL": "http://1.2.3.4"})
 def test_override_load_environmen_with_var():
-    os.environ["KUBE_API_URL"] = "http://1.2.3.4"
     secrets = load_secrets({
         "kubernetes": {
             "api_server_url": {


### PR DESCRIPTION
This is based on the other pull request I made, as adding additional testcases makes it less likely these changes will break something.

This also addresses issue #212, and changes the behavior of secrets loaded from a vault to match the behavior of secrets loaded from the environment.  It doesn't have to, but I figured I would change them to make them consistent.  If you'd prefer, I can keep the current behavior of get_secrets in this pull request and put in a separate pull request for #212.  

Other than that change, which didn’t have a testcase before, all the testcases, including some that I added along the way, still pass, so as far as I can tell, the changes I’ve made here should be transparent to the rest of the chaos library toolkit.