### PR TITLE
Correct mispelling 'continous' into 'continuous' to fit the PR 212 of…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.19.0...HEAD
 
+### Changed
+
+- Correct mispelling 'continous' into 'continuous' to fit the PR 212 of the chaostoolkit's cli.
+
 ## [1.19.0][] - 2021-02-16
 
 [1.19.0]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.18.3...1.19.0
@@ -258,7 +262,7 @@
   was interrupted from a control. With the strategies, you can now decide
   that they are always applied, never or only when the experiment deviated.
   This is a flag passed to the settings as follows:
-  
+
   ```
   runtime:
     rollbacks:
@@ -337,13 +341,13 @@
 ### Added
 
 - Optional default value for environment variable in configuration
-- Warn the user for an action process returning a non-zero exit code 
+- Warn the user for an action process returning a non-zero exit code
 - Support for process path relative to homedir ~
 - Indicate path in validation when path is not found nor executable [#159][159]
 
 ### Changed
 
-- Changed the method's one-step minimum requirement. 
+- Changed the method's one-step minimum requirement.
   An experiment with an empty method (without any activities) is now valid.
 
 [159]: https://github.com/chaostoolkit/chaostoolkit-lib/issues/159
@@ -455,7 +459,7 @@
 
 ### Changed
 
-- Fix to ensure a control's `configuration` parameter is populated when it the 
+- Fix to ensure a control's `configuration` parameter is populated when it the
   control is being `configured` [#114][114]
 - Load and apply global controls, those declared in the settings, from the
   `run_experiment` function rather than out of band [#116][116]
@@ -522,7 +526,7 @@
 #### Added
 
 - a new tolerance type called `range` to support scenarios such as:
-  
+
   value type is:
   ```
   {
@@ -887,7 +891,7 @@
 
 ### Changed
 
--   Log a message when loading the configuration 
+-   Log a message when loading the configuration
 -   Raise `InvalidExperiment` when a configuration or secret references a key
     in the environment and that key does not exist (it may not be set however)
     [#40][40]. This bails the experiment at validation time so before it runs.

--- a/chaoslib/run.py
+++ b/chaoslib/run.py
@@ -52,7 +52,7 @@ class RunEventHandler:
         logger.debug("Experiment execution caught a system signal")
 
     def start_continous_hypothesis(self, frequency: int) -> None:
-        logger.debug("Steady state will run continously now")
+        logger.debug("Steady state will run continuously now")
 
     def continous_hypothesis_iteration(self, iteration_index: int,
                                        state: Any) -> None:
@@ -62,7 +62,7 @@ class RunEventHandler:
                                        journal: Journal,
                                        exception: Exception = None) \
                                            -> None:
-        logger.debug("Continous steady state is now complete")
+        logger.debug("Continuous steady state is now complete")
 
     def start_hypothesis_before(self, experiment: Experiment) -> None:
         logger.debug("Steady state hypothesis is now running before method")
@@ -521,7 +521,7 @@ def run_hypothesis_during_method(hypo_pool: ThreadPoolExecutor,
                                  event_registry: EventHandlerRegistry,
                                  dry: bool = False) -> Future:
     """
-    Run the hypothesis continously in a background thead and report the
+    Run the hypothesis continuously in a background thead and report the
     status in the journal when it raised an exception.
     """
     def completed(f: Future):
@@ -535,7 +535,7 @@ def run_hypothesis_during_method(hypo_pool: ThreadPoolExecutor,
             elif isinstance(exc, Exception):
                 journal["status"] = "aborted"
                 logger.fatal(str(exc))
-        logger.info("Continous steady state hypothesis terminated")
+        logger.info("Continuous steady state hypothesis terminated")
 
     f = hypo_pool.submit(
         run_hypothesis_continuously, continous_hypo_event,
@@ -691,7 +691,7 @@ def run_hypothesis_continuously(event: threading.Event, schedule: Schedule,
 
     event_registry.start_continous_hypothesis(frequency)
     logger.info(
-        "Executing the steady-state hypothesis continously "
+        "Executing the steady-state hypothesis continuously "
         "every {} seconds".format(frequency))
 
     failed_iteration = 0
@@ -712,7 +712,7 @@ def run_hypothesis_continuously(event: threading.Event, schedule: Schedule,
             failed_ratio = (failed_iteration * 100) / iteration
             p = state["probes"][-1]
             logger.warning(
-                "Continous steady state probe '{p}' is not in the given "
+                "Continuous steady state probe '{p}' is not in the given "
                 "tolerance".format(p=p["activity"]["name"]))
 
             if schedule.fail_fast:

--- a/chaoslib/types.py
+++ b/chaoslib/types.py
@@ -49,7 +49,7 @@ class Strategy(enum.Enum):
     AFTER_METHOD = "after-method-only"
     DURING_METHOD = "during-method-only"
     DEFAULT = "default"
-    CONTINOUS = "continous"
+    CONTINOUS = "continuous"
 
     @staticmethod
     def from_string(value: str) -> 'Strategy':
@@ -61,9 +61,9 @@ class Strategy(enum.Enum):
             return Strategy.AFTER_METHOD
         elif value == "during-method-only":
             return Strategy.DURING_METHOD
-        elif value == "continously":
+        elif value == "continuously":
             return Strategy.CONTINOUS
-        elif value == "continously-fail-fast":
+        elif value == "continuously-fail-fast":
             return Strategy.CONTINOUS
 
         raise ValueError("Unknown strategy")


### PR DESCRIPTION
I made a PR in chaostoolkit/chaostoolkit to correct a mispelling issue.

If the PR 212 is merged in the cli, the changes in the current PR should ensure the communication between cli and lib.

I also correct other mispelling of the UI. I didn't change variables and methods to minimize the impact.

Sorry for last PR that I closed, i had some problems signing off my commits. 






Signed-off-by: camillegr <camille.gerin-roze@leanovia.com>