### PR TITLE
Fix stuck/interrupted experiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.19.1...HEAD
+[Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.19.0...HEAD
 
 ## [Unreleased][]
 
@@ -16,7 +16,7 @@ Therefore the experiment continues to run. [#210][ctk210]
 
 [ctk210]: https://github.com/chaostoolkit/chaostoolkit/issues/210
 
-[Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.19.1...HEAD
+[Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.19.0...HEAD
 
 ## [1.19.0][] - 2021-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,19 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.19.1...HEAD
 
-## [1.19.1][] - 2021-07-13
+## [Unreleased][]
 
 ### Removed
 - Remove the problematic log line from exit.py
 
-  While using the safeguards addon, when some safeguard probe fails, sometimes it doesn't stop the experiment and instead continues to run. In some cases it gets completely stuck.
+While using the safeguards addon, when some safeguard probe fails, sometimes it doesn't stop the experiment and instead continues to run. In some cases it gets completely stuck.
 
-  Problem is that the chaostoolkit uses Signals in order to interrupt threads. Sometimes the interrupt exception gets caught by that logger and it just swallows it.
-  Therefore the experiment continues to run. [#210][ctk210]
+Problem is that the chaostoolkit uses Signals in order to interrupt threads. Sometimes the interrupt exception gets caught by that logger and it just swallows it.
+Therefore the experiment continues to run. [#210][ctk210]
 
 [ctk210]: https://github.com/chaostoolkit/chaostoolkit/issues/210
 
-[1.19.1]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.19.0...1.19.1
+[Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.19.1...HEAD
 
 ## [1.19.0][] - 2021-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.19.0...HEAD
+[Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.19.1...HEAD
+
+## [1.19.1][] - 2021-07-13
+
+This is a fix for the following issue:
+[#210][ctk210]
+
+[ctk210]: https://github.com/chaostoolkit/chaostoolkit/issues/210
+
+- Remove the problematic log line from exit.py
+
+While using the safeguards addon, when some safeguard probe fails, sometimes it doesn't stop the experiment and instead continues to run. In some cases it gets completely stuck.
+
+Problem is that the chaostoolkit uses Signals in order to interrupt threads. Sometimes the interrupt exception gets caught by that logger and it just swallows it.
+Therefore the experiment continues to run.
+
+[1.19.1]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.19.0...1.19.1
 
 ## [1.19.0][] - 2021-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,15 @@
 
 ## [1.19.1][] - 2021-07-13
 
-This is a fix for the following issue:
-[#210][ctk210]
-
-[ctk210]: https://github.com/chaostoolkit/chaostoolkit/issues/210
-
+### Removed
 - Remove the problematic log line from exit.py
 
-While using the safeguards addon, when some safeguard probe fails, sometimes it doesn't stop the experiment and instead continues to run. In some cases it gets completely stuck.
+  While using the safeguards addon, when some safeguard probe fails, sometimes it doesn't stop the experiment and instead continues to run. In some cases it gets completely stuck.
 
-Problem is that the chaostoolkit uses Signals in order to interrupt threads. Sometimes the interrupt exception gets caught by that logger and it just swallows it.
-Therefore the experiment continues to run.
+  Problem is that the chaostoolkit uses Signals in order to interrupt threads. Sometimes the interrupt exception gets caught by that logger and it just swallows it.
+  Therefore the experiment continues to run. [#210][ctk210]
+
+[ctk210]: https://github.com/chaostoolkit/chaostoolkit/issues/210
 
 [1.19.1]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.19.0...1.19.1
 

--- a/chaoslib/exit.py
+++ b/chaoslib/exit.py
@@ -144,6 +144,8 @@ def _leave_now(signum: int, frame: FrameType = None) -> None:
     Signal handler only interested in SIGUSR1 and SIGUSR2 to indicate
     requested termination of the experiment.
     """
+    logger.warning("Caught signal num: '{}'".format(signum))
+
     if signum == signal.SIGUSR1:
         raise SystemExit(20)
 

--- a/chaoslib/exit.py
+++ b/chaoslib/exit.py
@@ -144,8 +144,6 @@ def _leave_now(signum: int, frame: FrameType = None) -> None:
     Signal handler only interested in SIGUSR1 and SIGUSR2 to indicate
     requested termination of the experiment.
     """
-    logger.warning("Caught signal num: '{}'".format(signum))
-
     if signum == signal.SIGUSR1:
         raise SystemExit(20)
 


### PR DESCRIPTION
This is a fix for the following issue:
https://github.com/chaostoolkit/chaostoolkit/issues/210

TL;DR

While using the safeguards addon, when some safeguard probe fails, sometimes it doesn't stop the experiment and instead continues to run. In some cases it gets completely stuck.

Problem is that the chaostoolkit uses Signals in order to interrupt threads. Sometimes the interrupt exception gets caught by that logger and it just swallows it.
Therefore the experiment continues to run.