### PR TITLE
Changed multiple references from `continous` to `continuous`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,55 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.20.0...HEAD
 
+### Changed
+
+- In `run.py`, changed method names: `start_continous_hypothesis` to
+  `start_continuous_hypothesis`, `continous_hypothesis_iteration` to
+  `continuous_hypothesis_iteration` and `continous_hypothesis_completed` to
+  `continuous_hypothesis_completed`
+
+- In `run.py`, changed variable `continous_hypo_event` to `continuous_hypo_event`
+
+- In `run.py`, changed `Strategy.CONTINOUS` to `Strategy.CONTINUOUS`
+
+- In `types.py`, changed `Strategy.CONTINOUS` to `Strategy.CONTINUOUS`
+
+- In `types.py`, changed expected `value` value from `continously` to
+  `continuously` and from `continously-fail-fast` to `continuously-fail-fast`
+
+- In `types.py`, changed expected paramater from `continous_hypothesis_frequency`
+  to `continuous_hypothesis_frequency`
+
+- In `test_run.py`, changed method names: `test_run_ssh_continous` to
+  `test_run_ssh_continuous`, `test_exit_continous_ssh_continous_when_experiment_is_interrupted`
+  to `test_exit_continuous_ssh_continuous_when_experiment_is_interrupted`,
+  `test_exit_continous_ssh_continous_when_experiment_is_exited` to
+  `test_exit_continuous_ssh_continuous_when_experiment_is_exited`,
+  `test_exit_continous_ssh_continous_when_activity_raises_unknown_exception` to
+  `test_exit_continuous_ssh_continuous_when_activity_raises_unknown_exception`,
+  `test_exit_immediatly_when_continous_ssh_fails_and_failfast` to
+  `test_exit_immediately_when_continuous_ssh_fails_and_failfast`,
+  `test_do_not_exit_when_continous_ssh_fails_and_no_failfast` to
+  `test_do_not_exit_when_continuous_ssh_fails_and_no_failfast`,
+  `test_exit_immediatly_when_continous_ssh_fails_and_failfast_when_background_activity` to
+  `test_exit_immediately_when_continuous_ssh_fails_and_failfast_when_background_activity`
+
+- In `test_run.py`, changed parameter `continous_hypothesis_frequency` to
+  `continuous_hypothesis_frequency` and variable strategy from `Strategy.CONTINOUS`
+  to `Strategy.CONTINUOUS`
+
+- In `test_run.py`, changed references: `start_continous_hypothesis` to
+  `start_continuous_hypothesis`, `continous_hypothesis_iteration` to
+  `continuous_hypothesis_iteration` and `continous_hypothesis_completed` to
+  `continuous_hypothesis_completed`
+
+- In `run_handlers.py`, changed method names: `continous_hypothesis_completed`
+  to `continuous_hypothesis_completed`, `continous_hypothesis_iteration` to
+  `continuous_hypothesis_iteration` and `continous_hypothesis_completed` to
+  `continuous_hypothesis_completed`
+
+- Changed other minor typos
+
 ## [1.20.0][] - 2021-08-17
 
 [1.20.0]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.19.0...1.20.0
@@ -193,8 +242,8 @@ Therefore the experiment continues to run. [#210][ctk210]
 
 - Add two functions to programmatically exit the experiment as soon as feasible
   by the Python VM [#185][185]:
-  * `chaoslib.exit.exit_gracefully`: termintes but abides to the rollback strategy
-  * `chaoslib.exit.exit_ungracefully`: termintes but bypasses rollbacks entirely
+  * `chaoslib.exit.exit_gracefully`: terminates but abides to the rollback strategy
+  * `chaoslib.exit.exit_ungracefully`: terminates but bypasses rollbacks entirely
     and does not wait for background actions/probes still running
   This should mostly be useful to have a harsh way to interrupt an execution
   and is therefore an advanced concept with undesirable side effects (though
@@ -229,7 +278,7 @@ Therefore the experiment continues to run. [#210][ctk210]
 
 - Steady-state hypothesos runtime strategies can be now set to determine if the
   the hypothesis is executed before/after the method as usual (default behavior)
-  or continously throughout the method too. Yo ucan also make it applied
+  or continuously throughout the method too. You can also make it applied
   before or after only, or even only during the method. [#191][191]
 
 [191]: https://github.com/chaostoolkit/chaostoolkit/pull/191
@@ -328,7 +377,7 @@ Therefore the experiment continues to run. [#210][ctk210]
 
 - Refactored run of the experiment so that we can have multiple run strategies
   such as not running the steady-state hypothesis before or after the method
-  but also one strategy so that the steady-state is continously applied
+  but also one strategy so that the steady-state is continuously applied
   during the method, with the option to bail the experiment as soon as it
   deviates. [#149][149]
 
@@ -968,7 +1017,7 @@ Therefore the experiment continues to run. [#210][ctk210]
 
 ### Changed
 
--   Steady stade is optional, so don't expect it here
+-   Steady state is optional, so don't expect it here
 
 ## [0.13.0][] - 2018-01-28
 
@@ -1127,7 +1176,7 @@ Therefore the experiment continues to run. [#210][ctk210]
 
 - Configuration schema support
 - Lots of logging added at the DEBUG level
-- [EXPERIMENTAL] Loading secrets froom HashiCorp vault
+- [EXPERIMENTAL] Loading secrets from HashiCorp vault
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - In `run.py`, changed `Strategy.CONTINOUS` to `Strategy.CONTINUOUS`
 
 - In `types.py`, changed `Strategy.CONTINOUS` to `Strategy.CONTINUOUS`
-  (BREAKING COMPATABILITY)
+  **(BREAKING COMPATABILITY)**
 
 - In `types.py`, changed expected `value` from `continously` to
   `continuously`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,50 +6,31 @@
 
 ### Changed
 
-- In `run.py`, changed method names: `start_continous_hypothesis` to
-  `start_continuous_hypothesis`, `continous_hypothesis_iteration` to
-  `continuous_hypothesis_iteration` and `continous_hypothesis_completed` to
-  `continuous_hypothesis_completed`
+- In `run.py`, changed method names containing `continous` to `continuous`
 
 - In `run.py`, changed variable `continous_hypo_event` to `continuous_hypo_event`
 
 - In `run.py`, changed `Strategy.CONTINOUS` to `Strategy.CONTINUOUS`
 
 - In `types.py`, changed `Strategy.CONTINOUS` to `Strategy.CONTINUOUS`
+  (BREAKING COMPATABILITY)
 
-- In `types.py`, changed expected `value` value from `continously` to
-  `continuously` and from `continously-fail-fast` to `continuously-fail-fast`
+- In `types.py`, changed expected `value` from `continously` to
+  `continuously`
 
 - In `types.py`, changed expected paramater from `continous_hypothesis_frequency`
   to `continuous_hypothesis_frequency`
 
-- In `test_run.py`, changed method names: `test_run_ssh_continous` to
-  `test_run_ssh_continuous`, `test_exit_continous_ssh_continous_when_experiment_is_interrupted`
-  to `test_exit_continuous_ssh_continuous_when_experiment_is_interrupted`,
-  `test_exit_continous_ssh_continous_when_experiment_is_exited` to
-  `test_exit_continuous_ssh_continuous_when_experiment_is_exited`,
-  `test_exit_continous_ssh_continous_when_activity_raises_unknown_exception` to
-  `test_exit_continuous_ssh_continuous_when_activity_raises_unknown_exception`,
-  `test_exit_immediatly_when_continous_ssh_fails_and_failfast` to
-  `test_exit_immediately_when_continuous_ssh_fails_and_failfast`,
-  `test_do_not_exit_when_continous_ssh_fails_and_no_failfast` to
-  `test_do_not_exit_when_continuous_ssh_fails_and_no_failfast`,
-  `test_exit_immediatly_when_continous_ssh_fails_and_failfast_when_background_activity` to
-  `test_exit_immediately_when_continuous_ssh_fails_and_failfast_when_background_activity`
+- In `test_run.py`, changed method names containing `continous` to `continuous`
+  and method names containing `immediatly` to `immediately`
 
 - In `test_run.py`, changed parameter `continous_hypothesis_frequency` to
   `continuous_hypothesis_frequency` and variable strategy from `Strategy.CONTINOUS`
   to `Strategy.CONTINUOUS`
 
-- In `test_run.py`, changed references: `start_continous_hypothesis` to
-  `start_continuous_hypothesis`, `continous_hypothesis_iteration` to
-  `continuous_hypothesis_iteration` and `continous_hypothesis_completed` to
-  `continuous_hypothesis_completed`
+- In `test_run.py`, changed method names containing `continous` to `continuous`
 
-- In `run_handlers.py`, changed method names: `continous_hypothesis_completed`
-  to `continuous_hypothesis_completed`, `continous_hypothesis_iteration` to
-  `continuous_hypothesis_iteration` and `continous_hypothesis_completed` to
-  `continuous_hypothesis_completed`
+- In `run_handlers.py`, changed method names containing `continous` to `continuous`
 
 - Changed other minor typos
 

--- a/chaoslib/run.py
+++ b/chaoslib/run.py
@@ -55,13 +55,12 @@ class RunEventHandler:
         logger.debug("Steady state will run continuously now")
 
     def continuous_hypothesis_iteration(self, iteration_index: int,
-                                       state: Any) -> None:
+                                        state: Any) -> None:
         logger.debug("Steady state iteration {}".format(iteration_index))
 
     def continuous_hypothesis_completed(self, experiment: Experiment,
-                                       journal: Journal,
-                                       exception: Exception = None) \
-                                           -> None:
+                                        journal: Journal,
+                                        exception: Exception = None) -> None:
         logger.debug("Continuous steady state is now complete")
 
     def start_hypothesis_before(self, experiment: Experiment) -> None:
@@ -154,7 +153,7 @@ class EventHandlerRegistry:
                         h.__class__.__name__), exc_info=True)
 
     def continuous_hypothesis_iteration(self, iteration_index: int,
-                                       state: Any) -> None:
+                                        state: Any) -> None:
         for h in self.handlers:
             try:
                 h.continuous_hypothesis_iteration(iteration_index, state)
@@ -164,8 +163,8 @@ class EventHandlerRegistry:
                         h.__class__.__name__), exc_info=True)
 
     def continuous_hypothesis_completed(self, experiment: Experiment,
-                                       journal: Journal,
-                                       exception: Exception = None) -> None:
+                                        journal: Journal,
+                                        exception: Exception = None) -> None:
         for h in self.handlers:
             try:
                 h.continuous_hypothesis_completed(

--- a/chaoslib/run.py
+++ b/chaoslib/run.py
@@ -51,18 +51,18 @@ class RunEventHandler:
     def signal_exit(self) -> None:
         logger.debug("Experiment execution caught a system signal")
 
-    def start_continous_hypothesis(self, frequency: int) -> None:
-        logger.debug("Steady state will run continously now")
+    def start_continuous_hypothesis(self, frequency: int) -> None:
+        logger.debug("Steady state will run continuously now")
 
-    def continous_hypothesis_iteration(self, iteration_index: int,
+    def continuous_hypothesis_iteration(self, iteration_index: int,
                                        state: Any) -> None:
         logger.debug("Steady state iteration {}".format(iteration_index))
 
-    def continous_hypothesis_completed(self, experiment: Experiment,
+    def continuous_hypothesis_completed(self, experiment: Experiment,
                                        journal: Journal,
                                        exception: Exception = None) \
                                            -> None:
-        logger.debug("Continous steady state is now complete")
+        logger.debug("Continuous steady state is now complete")
 
     def start_hypothesis_before(self, experiment: Experiment) -> None:
         logger.debug("Steady state hypothesis is now running before method")
@@ -144,32 +144,32 @@ class EventHandlerRegistry:
                     "Handler {} failed".format(
                         h.__class__.__name__), exc_info=True)
 
-    def start_continous_hypothesis(self, frequency: int) -> None:
+    def start_continuous_hypothesis(self, frequency: int) -> None:
         for h in self.handlers:
             try:
-                h.start_continous_hypothesis(frequency)
+                h.start_continuous_hypothesis(frequency)
             except Exception:
                 logger.debug(
                     "Handler {} failed".format(
                         h.__class__.__name__), exc_info=True)
 
-    def continous_hypothesis_iteration(self, iteration_index: int,
+    def continuous_hypothesis_iteration(self, iteration_index: int,
                                        state: Any) -> None:
         for h in self.handlers:
             try:
-                h.continous_hypothesis_iteration(iteration_index, state)
+                h.continuous_hypothesis_iteration(iteration_index, state)
             except Exception:
                 logger.debug(
                     "Handler {} failed".format(
                         h.__class__.__name__), exc_info=True)
 
-    def continous_hypothesis_completed(self, experiment: Experiment,
+    def continuous_hypothesis_completed(self, experiment: Experiment,
                                        journal: Journal,
                                        exception: Exception = None) \
                                            -> None:
         for h in self.handlers:
             try:
-                h.continous_hypothesis_completed(
+                h.continuous_hypothesis_completed(
                     experiment, journal, exception)
             except Exception:
                 logger.debug(
@@ -329,7 +329,7 @@ class Runner:
         control = Control()
         activity_pool, rollback_pool = get_background_pools(experiment)
         hypo_pool = get_hypothesis_pool()
-        continous_hypo_event = threading.Event()
+        continuous_hypo_event = threading.Event()
 
         dry = experiment.get("dry", False)
         if dry:
@@ -366,7 +366,7 @@ class Runner:
                 if state is not None:
                     if with_ssh and should_run_during_method(strategy):
                         run_hypothesis_during_method(
-                            hypo_pool, continous_hypo_event, strategy,
+                            hypo_pool, continuous_hypo_event, strategy,
                             schedule, experiment, journal, configuration,
                             secrets, event_registry, dry)
 
@@ -374,7 +374,7 @@ class Runner:
                             strategy, activity_pool, experiment, journal,
                             configuration, secrets, event_registry, dry)
 
-                    continous_hypo_event.set()
+                    continuous_hypo_event.set()
                     if journal["status"] not in ["interrupted", "aborted"]:
                         if with_ssh and (state is not None) and \
                                 should_run_after_method(strategy):
@@ -443,16 +443,16 @@ class Runner:
 
 def should_run_before_method(strategy: Strategy) -> bool:
     return strategy in [
-        Strategy.BEFORE_METHOD, Strategy.DEFAULT, Strategy.CONTINOUS]
+        Strategy.BEFORE_METHOD, Strategy.DEFAULT, Strategy.CONTINUOUS]
 
 
 def should_run_after_method(strategy: Strategy) -> bool:
     return strategy in [
-        Strategy.AFTER_METHOD, Strategy.DEFAULT, Strategy.CONTINOUS]
+        Strategy.AFTER_METHOD, Strategy.DEFAULT, Strategy.CONTINUOUS]
 
 
 def should_run_during_method(strategy: Strategy) -> bool:
-    return strategy in [Strategy.DURING_METHOD, Strategy.CONTINOUS]
+    return strategy in [Strategy.DURING_METHOD, Strategy.CONTINUOUS]
 
 
 def run_gate_hypothesis(experiment: Experiment, journal: Journal,
@@ -513,7 +513,7 @@ def run_deviation_validation_hypothesis(experiment: Experiment,
 
 
 def run_hypothesis_during_method(hypo_pool: ThreadPoolExecutor,
-                                 continous_hypo_event: threading.Event,
+                                 continuous_hypo_event: threading.Event,
                                  strategy: Strategy, schedule: Schedule,
                                  experiment: Experiment, journal: Journal,
                                  configuration: Configuration,
@@ -521,12 +521,12 @@ def run_hypothesis_during_method(hypo_pool: ThreadPoolExecutor,
                                  event_registry: EventHandlerRegistry,
                                  dry: bool = False) -> Future:
     """
-    Run the hypothesis continously in a background thead and report the
+    Run the hypothesis continuously in a background thread and report the
     status in the journal when it raised an exception.
     """
     def completed(f: Future):
         exc = f.exception()
-        event_registry.continous_hypothesis_completed(
+        event_registry.continuous_hypothesis_completed(
             experiment, journal, exc)
         if exc is not None:
             if isinstance(exc, InterruptExecution):
@@ -535,10 +535,10 @@ def run_hypothesis_during_method(hypo_pool: ThreadPoolExecutor,
             elif isinstance(exc, Exception):
                 journal["status"] = "aborted"
                 logger.fatal(str(exc))
-        logger.info("Continous steady state hypothesis terminated")
+        logger.info("Continuous steady state hypothesis terminated")
 
     f = hypo_pool.submit(
-        run_hypothesis_continuously, continous_hypo_event,
+        run_hypothesis_continuously, continuous_hypo_event,
         schedule, experiment, journal, configuration, secrets,
         event_registry, dry=dry)
     f.add_done_callback(completed)
@@ -595,7 +595,7 @@ def run_rollback(rollback_strategy: str, rollback_pool: ThreadPoolExecutor,
             play_rollbacks = True
         else:
             logger.warning(
-                "Rollbacks werre explicitely requested to be played "
+                "Rollbacks were explicitely requested to be played "
                 "only if the experiment deviated. Since this is not "
                 "the case, we will not play them.")
 
@@ -686,12 +686,12 @@ def run_hypothesis_continuously(event: threading.Event, schedule: Schedule,
                                 secrets: Secrets,
                                 event_registry: EventHandlerRegistry,
                                 dry: bool = False):
-    frequency = schedule.continous_hypothesis_frequency
+    frequency = schedule.continuous_hypothesis_frequency
     fail_fast_ratio = schedule.fail_fast_ratio
 
-    event_registry.start_continous_hypothesis(frequency)
+    event_registry.start_continuous_hypothesis(frequency)
     logger.info(
-        "Executing the steady-state hypothesis continously "
+        "Executing the steady-state hypothesis continuously "
         "every {} seconds".format(frequency))
 
     failed_iteration = 0
@@ -705,19 +705,19 @@ def run_hypothesis_continuously(event: threading.Event, schedule: Schedule,
         state = run_steady_state_hypothesis(
             experiment, configuration, secrets, dry=dry)
         journal["steady_states"]["during"].append(state)
-        event_registry.continous_hypothesis_iteration(iteration, state)
+        event_registry.continuous_hypothesis_iteration(iteration, state)
 
         if state is not None and not state["steady_state_met"]:
             failed_iteration += 1
             failed_ratio = (failed_iteration * 100) / iteration
             p = state["probes"][-1]
             logger.warning(
-                "Continous steady state probe '{p}' is not in the given "
+                "Continuous steady state probe '{p}' is not in the given "
                 "tolerance".format(p=p["activity"]["name"]))
 
             if schedule.fail_fast:
                 if failed_ratio >= fail_fast_ratio:
-                    m = "Terminating immediatly the experiment"
+                    m = "Terminating immediately the experiment"
                     if failed_ratio != 0.0:
                         m = "{} after {:.1f}% hypothesis deviated".format(
                             m, failed_ratio
@@ -844,7 +844,7 @@ def harshly_terminate_pending_background_activities(
     """
     Ugly hack to try to force background activities to terminate now.
 
-    This cano only have an impact over functions that are still in the Python
+    This can only have an impact over functions that are still in the Python
     land. Any code outside of the Python VM (say calling a C function, even
     time.sleep()) will not be impacted and therefore will continue hanging
     until it does complete of its own accord.

--- a/chaoslib/run.py
+++ b/chaoslib/run.py
@@ -165,8 +165,7 @@ class EventHandlerRegistry:
 
     def continuous_hypothesis_completed(self, experiment: Experiment,
                                        journal: Journal,
-                                       exception: Exception = None) \
-                                           -> None:
+                                       exception: Exception = None) -> None:
         for h in self.handlers:
             try:
                 h.continuous_hypothesis_completed(

--- a/chaoslib/types.py
+++ b/chaoslib/types.py
@@ -61,9 +61,7 @@ class Strategy(enum.Enum):
             return Strategy.AFTER_METHOD
         elif value == "during-method-only":
             return Strategy.DURING_METHOD
-        elif value in ["continously", "continuously"]:
-            return Strategy.CONTINUOUS
-        elif value in ["continously-fail-fast", "continuously-fail-fast"]:
+        elif value == "continuously":
             return Strategy.CONTINUOUS
 
         raise ValueError("Unknown strategy")

--- a/chaoslib/types.py
+++ b/chaoslib/types.py
@@ -49,7 +49,7 @@ class Strategy(enum.Enum):
     AFTER_METHOD = "after-method-only"
     DURING_METHOD = "during-method-only"
     DEFAULT = "default"
-    CONTINOUS = "continous"
+    CONTINUOUS = "continuous"
 
     @staticmethod
     def from_string(value: str) -> 'Strategy':
@@ -61,17 +61,17 @@ class Strategy(enum.Enum):
             return Strategy.AFTER_METHOD
         elif value == "during-method-only":
             return Strategy.DURING_METHOD
-        elif value == "continously":
-            return Strategy.CONTINOUS
-        elif value == "continously-fail-fast":
-            return Strategy.CONTINOUS
+        elif value == "continuously":
+            return Strategy.CONTINUOUS
+        elif value == "continuously-fail-fast":
+            return Strategy.CONTINUOUS
 
         raise ValueError("Unknown strategy")
 
 
 class Schedule:
-    def __init__(self, continous_hypothesis_frequency: float = 1.0,
+    def __init__(self, continuous_hypothesis_frequency: float = 1.0,
                  fail_fast: bool = False, fail_fast_ratio: float = 0):
-        self.continous_hypothesis_frequency = continous_hypothesis_frequency
+        self.continuous_hypothesis_frequency = continuous_hypothesis_frequency
         self.fail_fast = fail_fast
         self.fail_fast_ratio = fail_fast_ratio

--- a/chaoslib/types.py
+++ b/chaoslib/types.py
@@ -61,9 +61,9 @@ class Strategy(enum.Enum):
             return Strategy.AFTER_METHOD
         elif value == "during-method-only":
             return Strategy.DURING_METHOD
-        elif value == "continuously":
+        elif value in ["continously", "continuously"]:
             return Strategy.CONTINUOUS
-        elif value == "continuously-fail-fast":
+        elif value in ["continously-fail-fast", "continuously-fail-fast"]:
             return Strategy.CONTINUOUS
 
         raise ValueError("Unknown strategy")

--- a/tests/fixtures/run_handlers.py
+++ b/tests/fixtures/run_handlers.py
@@ -20,17 +20,17 @@ class FullRunEventHandler(RunEventHandler):
     def signal_exit(self) -> None:
         self.calls.append("signal_exit")
 
-    def start_continous_hypothesis(self, frequency: int) -> None:
-        self.calls.append("start_continous_hypothesis")
+    def start_continuous_hypothesis(self, frequency: int) -> None:
+        self.calls.append("start_continuous_hypothesis")
 
-    def continous_hypothesis_iteration(self, iteration_index: int,
+    def continuous_hypothesis_iteration(self, iteration_index: int,
                                        state: Any) -> None:
-        self.calls.append("continous_hypothesis_iteration")
+        self.calls.append("continuous_hypothesis_iteration")
 
-    def continous_hypothesis_completed(self, experiment: Experiment,
+    def continuous_hypothesis_completed(self, experiment: Experiment,
                                        journal: Journal,
                                        exception: Exception = None) -> None:
-        self.calls.append("continous_hypothesis_completed")
+        self.calls.append("continuous_hypothesis_completed")
 
     def start_method(self, experiment: Experiment) -> None:
         self.calls.append("start_method")
@@ -84,14 +84,14 @@ class FullExceptionRunEventHandler(RunEventHandler):
     def signal_exit(self) -> None:
         raise Exception()
 
-    def start_continous_hypothesis(self, frequency: int) -> None:
+    def start_continuous_hypothesis(self, frequency: int) -> None:
         raise Exception()
 
-    def continous_hypothesis_iteration(self, iteration_index: int,
+    def continuous_hypothesis_iteration(self, iteration_index: int,
                                        state: Any) -> None:
         raise Exception()
 
-    def continous_hypothesis_completed(self) -> None:
+    def continuous_hypothesis_completed(self) -> None:
         raise Exception()
 
     def start_rollbacks(self, experiment: Experiment) -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -46,18 +46,18 @@ def test_run_ssh_during_method_only():
     assert journal["steady_states"]["during"] is not None
 
 
-def test_run_ssh_continous():
+def test_run_ssh_continuous():
     experiment = experiments.SimpleExperiment.copy()
     journal = run_experiment(
-        experiment, strategy=Strategy.CONTINOUS,
-        schedule=Schedule(continous_hypothesis_frequency=0.1))
+        experiment, strategy=Strategy.CONTINUOUS,
+        schedule=Schedule(continuous_hypothesis_frequency=0.1))
     assert journal is not None
     assert journal["steady_states"]["before"] is not None
     assert journal["steady_states"]["after"] is not None
     assert journal["steady_states"]["during"] is not None
 
 
-def test_exit_continous_ssh_continous_when_experiment_is_interrupted():
+def test_exit_continuous_ssh_continuous_when_experiment_is_interrupted():
     handlers_called = []
     class Handler(RunEventHandler):
         def started(self, experiment: Experiment,
@@ -70,8 +70,8 @@ def test_exit_continous_ssh_continous_when_experiment_is_interrupted():
 
     experiment = experiments.SimpleExperimentWithInterruption.copy()
     journal = run_experiment(
-        experiment, strategy=Strategy.CONTINOUS,
-        schedule=Schedule(continous_hypothesis_frequency=0.1),
+        experiment, strategy=Strategy.CONTINUOUS,
+        schedule=Schedule(continuous_hypothesis_frequency=0.1),
         event_handlers=[Handler()])
     assert journal is not None
     assert journal["steady_states"]["before"] is not None
@@ -82,7 +82,7 @@ def test_exit_continous_ssh_continous_when_experiment_is_interrupted():
     assert sorted(handlers_called) == ["interrupted", "started"]
 
 
-def test_exit_continous_ssh_continous_when_experiment_is_exited():
+def test_exit_continuous_ssh_continuous_when_experiment_is_exited():
     handlers_called = []
     class Handler(RunEventHandler):
         def started(self, experiment: Experiment,
@@ -95,8 +95,8 @@ def test_exit_continous_ssh_continous_when_experiment_is_exited():
 
     experiment = experiments.SimpleExperimentWithExit.copy()
     journal = run_experiment(
-        experiment, strategy=Strategy.CONTINOUS,
-        schedule=Schedule(continous_hypothesis_frequency=0.1),
+        experiment, strategy=Strategy.CONTINUOUS,
+        schedule=Schedule(continuous_hypothesis_frequency=0.1),
         event_handlers=[Handler()])
     assert journal is not None
     assert journal["steady_states"]["before"] is not None
@@ -108,11 +108,11 @@ def test_exit_continous_ssh_continous_when_experiment_is_exited():
 
 
 
-def test_exit_continous_ssh_continous_when_activity_raises_unknown_exception():
+def test_exit_continuous_ssh_continuous_when_activity_raises_unknown_exception():
     experiment = experiments.SimpleExperimentWithException.copy()
     journal = run_experiment(
-        experiment, strategy=Strategy.CONTINOUS,
-        schedule=Schedule(continous_hypothesis_frequency=0.1),
+        experiment, strategy=Strategy.CONTINUOUS,
+        schedule=Schedule(continuous_hypothesis_frequency=0.1),
         settings={"runtime": {"rollbacks": {"strategy": "always"}}})
     assert journal is not None
     assert journal["steady_states"]["before"] is not None
@@ -125,11 +125,11 @@ def test_exit_continous_ssh_continous_when_activity_raises_unknown_exception():
     assert "oops" in journal["run"][-1]["exception"][-1]
 
 
-def test_exit_immediatly_when_continous_ssh_fails_and_failfast():
+def test_exit_immediately_when_continuous_ssh_fails_and_failfast():
     experiment = experiments.SimpleExperimentWithSSHFailingAtSomePoint.copy()
     journal = run_experiment(
-        experiment, strategy=Strategy.CONTINOUS,
-        schedule=Schedule(continous_hypothesis_frequency=0.1, fail_fast=True),
+        experiment, strategy=Strategy.CONTINUOUS,
+        schedule=Schedule(continuous_hypothesis_frequency=0.1, fail_fast=True),
         settings={"runtime": {"rollbacks": {"strategy": "always"}}})
     assert journal is not None
     assert journal["steady_states"]["before"] is not None
@@ -140,11 +140,11 @@ def test_exit_immediatly_when_continous_ssh_fails_and_failfast():
     assert len(journal["run"]) == 1
 
 
-def test_do_not_exit_when_continous_ssh_fails_and_no_failfast():
+def test_do_not_exit_when_continuous_ssh_fails_and_no_failfast():
     experiment = experiments.SimpleExperimentWithSSHFailingAtSomePoint.copy()
     journal = run_experiment(
-        experiment, strategy=Strategy.CONTINOUS,
-        schedule=Schedule(continous_hypothesis_frequency=0.1, fail_fast=False),
+        experiment, strategy=Strategy.CONTINUOUS,
+        schedule=Schedule(continuous_hypothesis_frequency=0.1, fail_fast=False),
         settings={"runtime": {"rollbacks": {"strategy": "always"}}})
     assert journal is not None
     assert journal["steady_states"]["before"] is not None
@@ -155,11 +155,11 @@ def test_do_not_exit_when_continous_ssh_fails_and_no_failfast():
     assert len(journal["run"]) == 2
 
 
-def test_exit_immediatly_when_continous_ssh_fails_and_failfast_when_background_activity():
+def test_exit_immediately_when_continuous_ssh_fails_and_failfast_when_background_activity():
     experiment = experiments.SimpleExperimentWithSSHFailingAtSomePointWithBackgroundActivity.copy()
     journal = run_experiment(
-        experiment, strategy=Strategy.CONTINOUS,
-        schedule=Schedule(continous_hypothesis_frequency=0.1, fail_fast=True),
+        experiment, strategy=Strategy.CONTINUOUS,
+        schedule=Schedule(continuous_hypothesis_frequency=0.1, fail_fast=True),
         settings={"runtime": {"rollbacks": {"strategy": "always"}}})
     assert journal is not None
     assert journal["steady_states"]["before"] is not None
@@ -180,9 +180,9 @@ def test_run_handler_is_called_on_each_handler():
     registry.finish(None)
     registry.interrupted(None, None)
     registry.signal_exit()
-    registry.start_continous_hypothesis(0)
-    registry.continous_hypothesis_iteration(0, None)
-    registry.continous_hypothesis_completed(None, None)
+    registry.start_continuous_hypothesis(0)
+    registry.continuous_hypothesis_iteration(0, None)
+    registry.continuous_hypothesis_completed(None, None)
     registry.start_method(None)
     registry.method_completed(None, None)
     registry.start_rollbacks(None)
@@ -196,8 +196,8 @@ def test_run_handler_is_called_on_each_handler():
 
     assert h.calls == [
         "started", "finish", "interrupted", "signal_exit",
-        "start_continous_hypothesis", "continous_hypothesis_iteration",
-        "continous_hypothesis_completed", "start_method", "method_completed",
+        "start_continuous_hypothesis", "continuous_hypothesis_iteration",
+        "continuous_hypothesis_completed", "start_method", "method_completed",
         "start_rollbacks", "rollbacks_completed", "start_hypothesis_before",
         "hypothesis_before_completed", "start_hypothesis_after",
         "hypothesis_after_completed",
@@ -215,9 +215,9 @@ def test_exceptions_does_not_stop_handler_registry():
     registry.finish(None)
     registry.interrupted(None, None)
     registry.signal_exit()
-    registry.start_continous_hypothesis(0)
-    registry.continous_hypothesis_iteration(0, None)
-    registry.continous_hypothesis_completed(None, None)
+    registry.start_continuous_hypothesis(0)
+    registry.continuous_hypothesis_iteration(0, None)
+    registry.continuous_hypothesis_completed(None, None)
     registry.start_method(None)
     registry.method_completed(None, None)
     registry.start_rollbacks(None)
@@ -231,8 +231,8 @@ def test_exceptions_does_not_stop_handler_registry():
 
     assert h.calls == [
         "started", "finish", "interrupted", "signal_exit",
-        "start_continous_hypothesis", "continous_hypothesis_iteration",
-        "continous_hypothesis_completed", "start_method", "method_completed",
+        "start_continuous_hypothesis", "continuous_hypothesis_iteration",
+        "continuous_hypothesis_completed", "start_method", "method_completed",
         "start_rollbacks", "rollbacks_completed", "start_hypothesis_before",
         "hypothesis_before_completed", "start_hypothesis_after",
         "hypothesis_after_completed",


### PR DESCRIPTION
There were many references across multiple repositories that misspelled `continuous` which I have now corrected

Previous PR: https://github.com/chaostoolkit/chaostoolkit-lib/pull/216

Related PRs: https://github.com/chaostoolkit/chaostoolkit/pull/235
                      https://github.com/chaostoolkit/chaostoolkit-documentation/pull/140

Signed-off-by: Charlie Moon <charlie@chaosiq.io>