### PR TITLE
Fix version extraction due to formatting changing ' to "

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ def get_version_from_package() -> str:
     with open(path) as f:
         for line in f:
             if line.startswith("__version__"):
-                token, version = line.split(" = ", 1)
-                version = version.replace("'", "").strip()
+                _, version = line.split(" = ", 1)
+                version = version.replace("\"", "").strip()
                 return version
 
 


### PR DESCRIPTION
Due to black changing `'`'s to `"`'s, the version extracting code will break,

This caused fun on `chaostoolkit-aws` and `chaostoolkit`, so catching it pre-release this time!

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
