### PR TITLE
Resolves #210

### DIFF
--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -10,12 +10,23 @@ from chaoslib.exceptions import InvalidExperiment
 from chaoslib.secret import create_vault_client, load_secrets, load_secrets_from_vault
 
 
+@patch.dict(os.environ, {"KUBE_API_URL": "http://1.2.3.4"})
 def test_should_load_environment():
-    os.environ["KUBE_API_URL"] = "http://1.2.3.4"
+<<<<<<< HEAD
+    secrets = load_secrets({
+        "kubernetes": {
+            "api_server_url": {
+                "type": "env",
+                "key": "KUBE_API_URL"
+            }
+        }
+    }, config.EmptyConfig)
+=======
     secrets = load_secrets(
         {"kubernetes": {"api_server_url": {"type": "env", "key": "KUBE_API_URL"}}},
         config.EmptyConfig,
     )
+>>>>>>> 6e72734 (Resolves #210)
     assert secrets["kubernetes"]["api_server_url"] == "http://1.2.3.4"
 
 
@@ -25,10 +36,13 @@ def test_should_load_inline():
     )
     assert secrets["kubernetes"]["api_server_url"] == "http://1.2.3.4"
 
+<<<<<<< HEAD
+=======
 
+>>>>>>> 6e72734 (Resolves #210)
+@patch.dict(os.environ, {"KUBE_API_URL": "http://1.2.3.4"})
 def test_should_merge_properly():
-    secrets = load_secrets(
-        {
+    secrets = load_secrets({
             "kubernetes": {
                 "username": "jane",
                 "address": {"host": "whatever", "port": 8090},
@@ -226,9 +240,12 @@ def test_read_secrets_from_vault_with_kv_version_2(hvac):
     secrets = load_secrets_from_vault(secrets_info, config)
     assert secrets["k8s"]["a-secret"] == "bar"
 
+<<<<<<< HEAD
+=======
 
+>>>>>>> 6e72734 (Resolves #210)
+@patch.dict(os.environ, {"KUBE_API_URL": "http://1.2.3.4"})
 def test_override_load_environmen_with_var():
-    os.environ["KUBE_API_URL"] = "http://1.2.3.4"
     secrets = load_secrets(
         {"kubernetes": {"api_server_url": {"type": "env", "key": "KUBE_API_URL"}}},
         config.EmptyConfig,


### PR DESCRIPTION
The tests are taking advantage in some places of os.environ being a global namespace.  They check to make sure that KUBE_API_URL is set to "http://1.2.3.4", but they don't actually explicitly set it.  Plus, os.environ is a system call, so it really should be mocked, not set in the testcase itself.

Signed-off-by: Kevin McKenzie <kmckenzi@us.ibm.com>