### PR TITLE
Resolves issue #209

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Switched from pycodestyle/pylama to `black`, `flake8`, `isort`
 * Update CI builds to build, lint, and test
+* Allow nesting of secrets
+* Secrets loaded from a vault can be overridden by variables
 
 ### Added
 

--- a/chaoslib/secret.py
+++ b/chaoslib/secret.py
@@ -89,7 +89,7 @@ def load_secrets(
                 secrets[key] = extra_vars.get(key)
 
             elif value.get("type") == "env":
-                secrets[key] = extra_vars or load_secret_from_env(value)
+                secrets[key] = load_secret_from_env(value)
 
             elif value.get("type") == "vault":
                 secrets[key] = load_secrets_from_vault(value, configuration)

--- a/chaoslib/secret.py
+++ b/chaoslib/secret.py
@@ -78,82 +78,55 @@ def load_secrets(
     """
     logger.debug("Loading secrets...")
 
-    loaders = (
-        load_inline_secrets,
-        load_secrets_from_env,
-        load_secrets_from_vault,
-    )
-
-    secrets = {}
     extra_vars = extra_vars or {}
-    for loader in loaders:
-        for key, value in loader(secrets_info, configuration, extra_vars).items():
-            if key not in secrets:
-                secrets[key] = {}
-            secrets[key].update(value)
 
-    logger.debug("Secrets loaded")
-
-    return secrets
-
-
-def load_inline_secrets(
-    secrets_info: Dict[str, Dict[str, str]],
-    configuration: Configuration = None,
-    extra_vars: Dict[str, Any] = None,
-) -> Secrets:
-    """
-    Load secrets that are inlined in the experiments.
-    """
     secrets = {}
 
-    for (target, keys) in secrets_info.items():
-        secrets[target] = {}
-        for (key, value) in keys.items():
-            if not isinstance(value, dict):
-                secrets[target][key] = extra_vars.get(target, {}).get(key, value)
-            elif value.get("type") not in ("env", "vault"):
-                secrets[target][key] = extra_vars.get(target, {}).get(key, value)
+    for (key, value) in secrets_info.items():
+        if isinstance(value, dict):
 
-        if not secrets[target]:
-            secrets.pop(target)
+            if extra_vars.get(key, None) is not None:
+                secrets[key] = extra_vars.get(key)
 
-    return secrets
+            elif value.get("type") == "env":
+                secrets[key] = extra_vars or load_secret_from_env(value)
 
+            elif value.get("type") == "vault":
+                secrets[key] = load_secrets_from_vault(value, configuration)
 
-def load_secrets_from_env(
-    secrets_info: Dict[str, Dict[str, str]],
-    configuration: Configuration = None,
-    extra_vars: Dict[str, Any] = None,
-) -> Secrets:
-    env = os.environ
-    secrets = {}
-
-    for (target, keys) in secrets_info.items():
-        secrets[target] = {}
-
-        for (key, value) in keys.items():
-            if isinstance(value, dict) and value.get("type") == "env":
-                env_key = value["key"]
-                if (env_key not in env) and (key not in extra_vars.get("target", {})):
-                    raise InvalidExperiment(
-                        "Secrets make reference to an environment key "
-                        "that does not exist: {}".format(env_key)
-                    )
-                secrets[target][key] = extra_vars.get(target, {}).get(
-                    key, env.get(env_key)
+            else:
+                secrets[key] = load_secrets(
+                    value, configuration, extra_vars.get(key, None)
                 )
 
-        if not secrets[target]:
-            secrets.pop(target)
+        else:
+            secrets[key] = value
+
+    logger.debug("Done loading secrets")
 
     return secrets
+
+
+def load_secret_from_env(secrets_info: Dict[str, Dict[str, str]]) -> Secrets:
+    env = os.environ
+
+    if isinstance(secrets_info, dict) and secrets_info.get("type") == "env":
+
+        env_key = secrets_info["key"]
+        if env_key not in env:
+            raise InvalidExperiment(
+                "Secrets make reference to an environment key "
+                "that does not exist: {}".format(env_key)
+            )
+        else:
+            secret = env[env_key]
+
+    return secret
 
 
 def load_secrets_from_vault(
     secrets_info: Dict[str, Dict[str, str]],  # noqa: C901
     configuration: Configuration = None,
-    extra_vars: Dict[str, Any] = None,
 ) -> Secrets:
     """
     Load secrets from Vault KV secrets store
@@ -200,73 +173,57 @@ def load_secrets_from_vault(
     In that case, `mykey` will be set to the value at `secret/foo/bar` under
     the Vault secret key `mypassword`.
     """
-    secrets = {}
+
+    secret = {}
 
     client = create_vault_client(configuration)
 
-    for (target, keys) in secrets_info.items():
-        secrets[target] = {}
+    if isinstance(secrets_info, dict) and secrets_info.get("type") == "vault":
 
-        for (key, value) in keys.items():
-            if isinstance(value, dict) and value.get("type") == "vault":
-                if not HAS_HVAC:
-                    logger.error(
-                        "Install the `hvac` package to fetch secrets "
-                        "from Vault: `pip install chaostoolkit-lib[vault]`."
-                    )
-                    return {}
+        if not HAS_HVAC:
+            logger.error(
+                "Install the `hvac` package to fetch secrets "
+                "from Vault: `pip install chaostoolkit-lib[vault]`."
+            )
+            return {}
 
-                path = value.get("path")
-                if path is None:
-                    logger.warning("Missing Vault secret path for '{}'".format(key))
-                    continue
+        vault_path = secrets_info.get("path")
 
-                # see https://github.com/chaostoolkit/chaostoolkit/issues/98
-                kv = client.secrets.kv
-                is_kv1 = kv.default_kv_version == "1"
-                if is_kv1:
-                    vault_payload = kv.v1.read_secret(
-                        path=path,
-                        mount_point=configuration.get(
-                            "vault_secrets_mount_point", "secret"
-                        ),
-                    )
-                else:
-                    vault_payload = kv.v2.read_secret_version(
-                        path=path,
-                        mount_point=configuration.get(
-                            "vault_secrets_mount_point", "secret"
-                        ),
-                    )
+        if vault_path is None:
+            logger.warning("Missing Vault secret path for '{}'".format(secrets_info))
+            return {}
 
-                if not vault_payload:
-                    logger.warning("No Vault secret found at path: {}".format(path))
-                    continue
+        # see https://github.com/chaostoolkit/chaostoolkit/issues/98
+        kv = client.secrets.kv
+        is_kv1 = kv.default_kv_version == "1"
+        if is_kv1:
+            vault_payload = kv.v1.read_secret(
+                path=vault_path,
+                mount_point=configuration.get("vault_secrets_mount_point", "secret"),
+            )
+        else:
+            vault_payload = kv.v2.read_secret_version(
+                path=vault_path,
+                mount_point=configuration.get("vault_secrets_mount_point", "secret"),
+            )
 
-                if is_kv1:
-                    data = vault_payload.get("data")
-                else:
-                    data = vault_payload.get("data", {}).get("data")
+        if not vault_payload:
+            logger.warning("No Vault secret found at path: {}".format(vault_path))
+            return {}
 
-                if "key" in value:
-                    vault_key = value["key"]
-                    if vault_key not in data:
-                        logger.warning(
-                            "No Vault key '{}' at secret path '{}'".format(
-                                vault_key, path
-                            )
-                        )
-                        continue
+        if is_kv1:
+            data = vault_payload.get("data")
+        else:
+            data = vault_payload.get("data", {}).get("data")
 
-                    secrets[target][key] = data.get(vault_key)
+        key = secrets_info.get("key")
 
-                else:
-                    secrets[target][key] = data
+        if key is not None:
+            secret = data[key]
+        else:
+            secret = data
 
-        if not secrets[target]:
-            secrets.pop(target)
-
-    return secrets
+        return secret
 
 
 ###############################################################################

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -19,6 +19,26 @@ def test_should_load_environment():
     assert secrets["kubernetes"]["api_server_url"] == "http://1.2.3.4"
 
 
+@patch.dict(os.environ, {"KUBE_API_URL": "http://1.2.3.4"})
+def test_should_load_nested_environment():
+    secrets = load_secrets(
+        {
+            "kubernetes": {
+                "env1": {
+                    "username": "jane",
+                    "address": {"host": "whatever", "port": 8090},
+                    "api_server_url": {"type": "env", "key": "KUBE_API_URL"},
+                }
+            }
+        },
+        config.EmptyConfig,
+    )
+    assert secrets["kubernetes"]["env1"]["username"] == "jane"
+    assert secrets["kubernetes"]["env1"]["address"]["host"] == "whatever"
+    assert secrets["kubernetes"]["env1"]["address"]["port"] == 8090
+    assert secrets["kubernetes"]["env1"]["api_server_url"] == "http://1.2.3.4"
+
+
 def test_should_load_inline():
     secrets = load_secrets(
         {"kubernetes": {"api_server_url": "http://1.2.3.4"}}, config.EmptyConfig
@@ -160,7 +180,7 @@ def test_read_secrets_from_vault_with_kv_version_1(hvac):
     hvac.Client.return_value = fake_client
     fake_client.secrets.kv.v1.read_secret.return_value = vault_secret_payload
 
-    secrets = load_secrets_from_vault(secrets_info, config)
+    secrets = load_secrets(secrets_info, config)
     assert secrets["k8s"]["a-secret"] == {
         "my-important-secret": "bar",
         "my-less-important-secret": "baz",
@@ -176,7 +196,7 @@ def test_read_secrets_from_vault_with_kv_version_1(hvac):
         }
     }
 
-    secrets = load_secrets_from_vault(secrets_info, config)
+    secrets = load_secrets(secrets_info, config)
     assert secrets["k8s"]["a-secret"] == "bar"
 
 
@@ -207,7 +227,7 @@ def test_read_secrets_from_vault_with_kv_version_2(hvac):
     hvac.Client.return_value = fake_client
     fake_client.secrets.kv.v2.read_secret_version.return_value = vault_secret_payload
 
-    secrets = load_secrets_from_vault(secrets_info, config)
+    secrets = load_secrets(secrets_info, config)
     assert secrets["k8s"]["a-secret"] == {
         "my-important-secret": "bar",
         "my-less-important-secret": "baz",
@@ -223,7 +243,7 @@ def test_read_secrets_from_vault_with_kv_version_2(hvac):
         }
     }
 
-    secrets = load_secrets_from_vault(secrets_info, config)
+    secrets = load_secrets(secrets_info, config)
     assert secrets["k8s"]["a-secret"] == "bar"
 
 
@@ -244,3 +264,105 @@ def test_should_override_load_inline_with_var():
         {"kubernetes": {"api_server_url": "http://elsewhere"}},
     )
     assert secrets["kubernetes"]["api_server_url"] == "http://elsewhere"
+
+
+@patch("chaoslib.secret.hvac")
+def test_vault_add_subkeys(hvac):
+    config = {
+        "vault_addr": "http://someaddr.com",
+        "vault_token": "not_awesome_token",
+        "vault_kv_version": "2",
+    }
+
+    vault_secret_payload = {
+        "data": {
+            "data": {"foo": "bar", "baz": "hello"},
+            "metadata": {
+                "auth": None,
+                "lease_duration": 2764800,
+                "lease_id": "",
+                "renewable": False,
+            },
+        }
+    }
+
+    fake_client = MagicMock()
+    hvac.Client.return_value = fake_client
+    fake_client.secrets.kv.v2.read_secret_version.return_value = vault_secret_payload
+
+    secrets = load_secrets(
+        {"myapp": {"token": {"type": "vault", "path": "secrets/something"}}}, config
+    )
+    assert secrets["myapp"]["token"]["foo"] == "bar"
+    assert secrets["myapp"]["token"]["baz"] == "hello"
+
+
+@patch("chaoslib.secret.hvac")
+def test_vault_replace_entire_declare(hvac):
+    config = {
+        "vault_addr": "http://someaddr.com",
+        "vault_token": "not_awesome_token",
+        "vault_kv_version": "2",
+    }
+
+    vault_secret_payload = {
+        "data": {
+            "data": {"foo": "bar", "baz": "hello"},
+            "metadata": {
+                "auth": None,
+                "lease_duration": 2764800,
+                "lease_id": "",
+                "renewable": False,
+            },
+        }
+    }
+
+    fake_client = MagicMock()
+    hvac.Client.return_value = fake_client
+    fake_client.secrets.kv.v2.read_secret_version.return_value = vault_secret_payload
+
+    secrets = load_secrets(
+        {
+            "myapp": {
+                "token": {"type": "vault", "path": "secrets/something", "key": "foo"}
+            }
+        },
+        config,
+    )
+    assert secrets["myapp"]["token"] == "bar"
+
+
+@patch("chaoslib.secret.hvac")
+def test_override_vault_with_vars(hvac):
+    config = {
+        "vault_addr": "http://someaddr.com",
+        "vault_token": "not_awesome_token",
+        "vault_kv_version": "2",
+    }
+
+    vault_secret_payload = {
+        "data": {
+            "data": {"foo": "bar", "baz": "hello"},
+            "metadata": {
+                "auth": None,
+                "lease_duration": 2764800,
+                "lease_id": "",
+                "renewable": False,
+            },
+        }
+    }
+
+    fake_client = MagicMock()
+    hvac.Client.return_value = fake_client
+    fake_client.secrets.kv.v2.read_secret_version.return_value = vault_secret_payload
+
+    secrets = load_secrets(
+        {
+            "myapp": {
+                "token": {"type": "vault", "path": "secrets/something", "key": "foo"}
+            }
+        },
+        config,
+        {"myapp": {"token": "baz"}},
+    )
+    assert secrets["myapp"]["token"] == "baz"

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -7,7 +7,7 @@ from fixtures import config
 from hvac.exceptions import InvalidRequest
 
 from chaoslib.exceptions import InvalidExperiment
-from chaoslib.secret import create_vault_client, load_secrets, load_secrets_from_vault
+from chaoslib.secret import create_vault_client, load_secrets
 
 
 def test_should_load_environment():


### PR DESCRIPTION
This allows for indefinitely nested secrets files.  I also address #212, so if you override a secret loaded from a vault, it will be overridden the same way a secret loaded from the environment is overridden.  This is for consistency’s sake, but if there’s a reason to preserve the old behavior, that could be done.  I also made some changes to a couple of testcases to use the load_secrets function as opposed to the load_secrets_from_vault function.

Signed-off-by: Kevin McKenzie <kmckenzi@us.ibm.com>