### PR TITLE
Add Close Stale Issues workflow to Actions

### DIFF
--- a/.github/workflows/close_stale_issues.yaml
+++ b/.github/workflows/close_stale_issues.yaml
@@ -1,0 +1,23 @@
+name: Close Stale Issues
+on:
+  workflow_dispatch:
+  schedule:
+    # Every Sunday at 00:00
+    - cron: '0 0 * * 0'
+
+jobs:
+  close-stale-issues:
+    permissions:
+      issues: write
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/stale@v4
+        with:
+          operations-per-run: 200
+          stale-issue-message: 'This Issue has not been active in 365 days. To re-activate this Issue, remove the `Stale` label or comment on it. If not re-activated, this Issue will be closed in 7 days.'
+          close-issue-message: 'This Issue was closed because it was not reactivated after 7 days of being marked `Stale`.'
+          days-before-issue-stale: 365
+          days-before-issue-close: 7
+          # For now, don't mark PRs stale and don't close them
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Allow nesting of secrets
 * Secrets loaded from a vault can be overridden by variables
 * In secrets testcases, change the os.environ to be a patch, not an assignment within the testcase.
+* Add `.github/workflows/close_stale_issues.yaml` to mark issues as `Stale`
+after 365 days of inactivity and to close them after 7 days of being marked
+`Stale`.
 
 ### Added
 


### PR DESCRIPTION
This PR adds the `Close Stale Issues` workflow which runs every Sunday.

The workflow marks inactive issues (of 365 days) as `Stale`. If an issue
is not touched within 7 days of being `Stale`, it is closed.
