### PR TITLE
Updated Workflow + Makefile

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,44 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
 
 jobs:
+check-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Get changed files
+        uses: tj-actions/changed-files@v1.1.2
+        id: files
+      - name: Determine if files modified
+        run: |
+          init_modified=false
+          changelog_modified=false
+          for changed_file in ${{ steps.files.outputs.all_modified_files }}; do
+            if [[ ${changed_file} == "chaoslib/__init__.py" ]];
+            then
+              init_modified=true # __init__.py was modified
+            elif [[ ${changed_file} == "CHANGELOG.md" ]];
+            then
+              changelog_modified=true # CHANGELOG.md was modified
+            fi
+          done
+          if [[ ${init_modified} == false ]];
+          then
+            echo "__init__.py was not modified"
+          fi
+          if [[ ${changelog_modified} == false ]];
+          then
+            echo "CHANGELOG.md was not modified"
+          fi
+          if [[ ${init_modified} == false || ${changelog_modified} == false ]];
+          then
+            exit 1
+          fi
+          exit 0
   release-to-pypi:
-    runs-on: ubuntu-16.04
+  needs: [check-release]
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
           fi
           exit 0
   release-to-pypi:
-  needs: [check-release]
+    needs: [check-release]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
 
 jobs:
-check-release:
+  check-release:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 * Switched from pycodestyle/pylama to `black`, `flake8`, `isort`
 * Update CI builds to build, lint, and test
+* Updated `.github/workflows/release.yaml` to check that both `CHANGELOG.md`
+and `chaoslib/__init__.py` get updated in line with a new version
+* Updated `Makefile` to specify `python3` instead of `python`
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ install:
 .PHONY: install-dev
 install-dev: install
 	pip install -r requirements-dev.txt
-	python setup.py develop
+	python3 setup.py develop
 
 .PHONY: build
 build:
-	python setup.py build
+	python3 setup.py build
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
Updated the `release.yaml` workflow to ensure that `CHANGELOG.md` and `chaoslib/__init__.py` are updated in the event of a new release
Changed the `Makefile` to explicitly run python 3+ to avoid syntax errors caused by more recent python versions