### PR TITLE
Attempt to fix `test/test_exit.py` tests by using `pytest-docker`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,4 +53,4 @@ jobs:
           make install-dev
       - name: Run tests
         run: |
-          pytest
+          make tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,4 +53,4 @@ jobs:
           make install-dev
       - name: Run tests
         run: |
-          make tests
+          pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * `notifications.py` now uses PayloadEncoder to serialise `datetime` objects
   and `Exception` objects for when using `notify_with_http`.
+* `test/test_exit.py` was blocking on `server.join()`, this is now refactored
+  out into a lightweight FastAPI container which is spun up for the unit tests
+  so that we don't mess around with threading in test code. This now means we
+  can run `test_exit.py` in CI as well, where we were previously skipping it.
 
 ### Changed
 
@@ -24,6 +28,9 @@
   * UUIDs
   * Decimals
   * Exceptions
+* Added `pytest-docker` so that we can run containers during tests
+* Moved `tests/test_exit.py` to `tests/test_exit/test_exit.py` so that it is
+  separated from other test setup with its Dockerfile etc.
 
 ## [1.22.1][] - 2021-10-04
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ isort
 jsonpath2
 pytest~=6.2
 pytest-cov
+pytest-docker
 pytest-sugar
 ply
 pyhcl

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tempfile
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -10,8 +11,8 @@ from chaoslib.configuration import load_configuration
 from chaoslib.exceptions import InvalidExperiment
 
 
+@patch.dict(os.environ, {"KUBE_TOKEN": "value2"})
 def test_should_load_configuration():
-    os.environ["KUBE_TOKEN"] = "value2"
     config = load_configuration(
         {
             "token1": "value1",
@@ -25,9 +26,8 @@ def test_should_load_configuration():
     assert config["token3"] == "value3"
 
 
+@patch.dict(os.environ, {"KUBE_TOKEN": "value2"})
 def test_should_load_configuration_with_empty_string_as_default():
-    os.environ.clear()
-    os.environ["KUBE_TOKEN"] = "value2"
     config = load_configuration(
         {
             "token1": "value1",
@@ -41,9 +41,8 @@ def test_should_load_configuration_with_empty_string_as_default():
     assert config["token3"] == ""
 
 
+@patch.dict(os.environ, {"KUBE_TOKEN": ""})
 def test_should_load_configuration_with_empty_string_as_input():
-    os.environ.clear()
-    os.environ["KUBE_TOKEN"] = ""
     config = load_configuration(
         {
             "token1": "value1",
@@ -57,9 +56,8 @@ def test_should_load_configuration_with_empty_string_as_input():
     assert config["token3"] == "value3"
 
 
+@patch.dict(os.environ, {"KUBE_TOKEN": ""})
 def test_should_load_configuration_with_empty_string_as_input_while_default_is_define():
-    os.environ.clear()
-    os.environ["KUBE_TOKEN"] = ""
     config = load_configuration(
         {
             "token1": "value1",
@@ -74,7 +72,6 @@ def test_should_load_configuration_with_empty_string_as_input_while_default_is_d
 
 
 def test_load_configuration_should_raise_exception():
-    os.environ.clear()
     with pytest.raises(InvalidExperiment) as x:
         load_configuration(
             {
@@ -90,8 +87,8 @@ def test_load_configuration_should_raise_exception():
     )
 
 
+@patch.dict(os.environ, {"KUBE_TOKEN": "value2"})
 def test_can_override_experiment_inline_config_keys():
-    os.environ["KUBE_TOKEN"] = "value2"
     config = load_configuration(
         {
             "token1": "value1",
@@ -106,8 +103,8 @@ def test_can_override_experiment_inline_config_keys():
     assert config["token3"] == "value3"
 
 
+@patch.dict(os.environ, {"KUBE_TOKEN": "value2"})
 def test_default_value_is_overriden_in_inline_config_keys():
-    os.environ["KUBE_TOKEN"] = "value2"
     config = load_configuration(
         {
             "token1": "value1",
@@ -184,7 +181,6 @@ def test_read_env_from_env_file():
         f.seek(0)
         merge_vars(var_files=[f.name])
         assert os.environ["STUFF"] == "todo"
-        os.environ.clear()
 
 
 def test_convert_int_var():
@@ -217,8 +213,8 @@ def test_convert_invalid_type():
         convert_vars(["todo:object=stuff"])
 
 
+@patch.dict(os.environ, {"KUBE_TOKEN": "value2"})
 def test_should_override_load_configuration_with_var():
-    os.environ["KUBE_TOKEN"] = "value2"
     config = load_configuration(
         {
             "token1": "value1",
@@ -235,7 +231,6 @@ def test_should_override_load_configuration_with_var():
 
 # see https://github.com/chaostoolkit/chaostoolkit-lib/issues/195
 def test_load_nested_object_configuration():
-    os.environ.clear()
     config = load_configuration(
         {"nested": {"onea": "fdsfdsf", "lol": {"haha": [1, 2, 3]}}}
     )

--- a/tests/test_exit/conftest.py
+++ b/tests/test_exit/conftest.py
@@ -1,0 +1,30 @@
+import os
+
+import requests
+from logzero import logger
+from pytest import fixture
+
+
+def check_slow_service() -> bool:
+    try:
+        resp = requests.get("http://localhost:8700")
+        resp.raise_for_status()
+        logger.debug("test_exit.py's slow_service is ready!")
+        return True
+    except Exception:
+        logger.debug("test_exit.py's slow_service not yet ready, trying again.")
+        return False
+
+
+@fixture(scope="session")
+def docker_compose_file(pytestconfig) -> str:
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "docker-compose.yaml"
+    )
+
+
+@fixture(scope="class")
+def slow_service(docker_services) -> None:
+    docker_services.wait_until_responsive(
+        timeout=30.0, pause=10, check=lambda: check_slow_service()
+    )

--- a/tests/test_exit/docker-compose.yaml
+++ b/tests/test_exit/docker-compose.yaml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  web:
+    build: ./slow_service/
+    ports:
+      - "8700:80"

--- a/tests/test_exit/slow_service/Dockerfile
+++ b/tests/test_exit/slow_service/Dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8
+
+COPY ./app /app

--- a/tests/test_exit/slow_service/app/main.py
+++ b/tests/test_exit/slow_service/app/main.py
@@ -1,0 +1,11 @@
+import time
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    time.sleep(5)
+    return "Hello world"


### PR DESCRIPTION
Due to the threading used in `tests/test_exit.py`, the tests always hang on `server.join()`

Rather than running an http service in a thread, I'm trying out using `pytest-docker` to run a http service in a container alongside the tests. Whilst this introduces the need to have `docker` and `docker-compose` locally (I don't think that's a massive ask for developers...), it reduces the complexity of the test and doesn't rely on some scary threading

**Update**

I can confirm that this unblocks the tests locally **AND** we can now run them in CI builds too (🤙 🤙 🤙 )

To summarise, this PR:

* Removes scary threading in `test_exit.py` in favour of running a very lightweight FastAPI container which does the exact same thing
* Unblocks local running of `test_exit.py` **and** enables running them in CI
* Adds `pytest-docker` as a dev dependency (and because of it, `docker` and `docker-compose`)
* Removes nasty handling of `os.environ` which would affect any test being run, not just the tests in `test_configuration.py`

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
