### PR TITLE
Add support for specifying a type for `env` type configuration values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.23.0...HEAD
 
+### Added
+
+* Configuration now supports providing a type to convert Environment Variables
+  to a provided type. Addressing the issue [here](https://github.com/chaostoolkit/chaostoolkit/issues/254#issue-1062797767)
+  To specifically convert an Environment Variable loaded into configuration to
+  a type, provide the `env_var_type` key in the same block as the "env" declaration.
+  Supported values are: `str, int, float, bytes`.
+
 ## [1.23.0][] - 2021-11-05
 
 

--- a/chaoslib/__init__.py
+++ b/chaoslib/__init__.py
@@ -268,16 +268,7 @@ def convert_vars(value: List[str]) -> Dict[str, Any]:  # noqa: C901
             if ":" in k:
                 k, typ = k.rsplit(":", 1)
                 try:
-                    if typ == "str":
-                        pass
-                    elif typ == "int":
-                        v = int(v)
-                    elif typ == "float":
-                        v = float(v)
-                    elif typ == "bytes":
-                        v = v.encode("utf-8")
-                    else:
-                        raise ValueError("var supports only: str, int, float and bytes")
+                    v = convert_to_type(typ, v)
                 except (TypeError, UnicodeEncodeError):
                     raise ValueError("var cannot convert value to required type")
             var[k] = v
@@ -287,6 +278,28 @@ def convert_vars(value: List[str]) -> Dict[str, Any]:  # noqa: C901
             raise ValueError("var needs to be in the format name[:type]=value")
 
     return var
+
+
+def convert_to_type(type: str, val: str) -> Union[str, int, float, bytes]:
+    """
+    Converts a value to a provided type. If `type` is None, then the original string is
+    returned, else the val is coerced into the provided type. An exception is thrown
+    if the type is not supported.
+
+    :param type: str representing what type to convert `val` to
+    :param val: str representing the variable loaded in to configuration
+    :returns: Union[str, int, float, bytes] representing the converted value
+    """
+    if type is None or type == "str":
+        return val
+    elif type == "int":
+        return int(val)
+    elif type == "float":
+        return float(val)
+    elif type == "bytes":
+        return val.encode("utf-8")
+    else:
+        raise ValueError("variables can only be: str, int, float, or bytes")
 
 
 class PayloadEncoder(JSONEncoder):

--- a/chaoslib/configuration.py
+++ b/chaoslib/configuration.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 
 from logzero import logger
 
+from chaoslib import convert_to_type
 from chaoslib.exceptions import InvalidExperiment
 from chaoslib.types import Configuration
 
@@ -35,6 +36,11 @@ def load_configuration(
             "type": "env",
             "key": "HOSTNAME",
             "default": "localhost"
+        },
+        "port": {
+            "type": "env",
+            "key": "SERVICE_PORT",
+            "env_var_type": "int"
         }
     }
     ```
@@ -43,7 +49,9 @@ def load_configuration(
     configuration key is dynamically fetched from the `MY_TOKEN` environment
     variable. The `host` configuration key is dynamically fetched from the
     `HOSTNAME` environment variable, but if not defined, the default value
-    `localhost` will be used instead.
+    `localhost` will be used instead. The `port` configuration key is dynamically
+    fetched from the `SERVICE_PORT` environment variable. It is coerced into an `int`
+    with the addition of the `env_var_type` key.
 
     When `extra_vars` is provided, it must be a dictionnary where keys map
     to configuration key. The values from `extra_vars` always override the
@@ -70,7 +78,11 @@ def load_configuration(
                         "Configuration makes reference to an environment key"
                         " that does not exist: {}".format(env_key)
                     )
-                conf[key] = extra_vars.get(key, env.get(env_key, env_default))
+                env_var_type = value.get("env_var_type")
+                env_var_value = convert_to_type(
+                    env_var_type, env.get(env_key, env_default)
+                )
+                conf[key] = extra_vars.get(key, env_var_value)
         else:
             conf[key] = extra_vars.get(key, value)
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -240,3 +240,43 @@ def test_load_nested_object_configuration():
     assert isinstance(config["nested"], dict)
     assert config["nested"]["onea"] == "fdsfdsf"
     assert config["nested"]["lol"] == {"haha": [1, 2, 3]}
+
+
+@patch.dict(
+    "os.environ",
+    {
+        "TEST_ENV_VAR_NO_TYPE": "should_be_a_string",
+        "TEST_ENV_VAR_STRING": "should_also_be_a_string",
+        "TEST_ENV_VAR_INT": "1000",
+        "TEST_ENV_VAR_FLOAT": "30.54321",
+        "TEST_ENV_VAR_BYTES": "these_are_bytes",
+    },
+)
+def test_that_environment_variables_are_typed_correctly():
+    config = load_configuration(
+        {
+            "token1": {"type": "env", "key": "TEST_ENV_VAR_NO_TYPE"},
+            "token2": {
+                "type": "env",
+                "key": "TEST_ENV_VAR_STRING",
+                "env_var_type": "str",
+            },
+            "token3": {"type": "env", "key": "TEST_ENV_VAR_INT", "env_var_type": "int"},
+            "token4": {
+                "type": "env",
+                "key": "TEST_ENV_VAR_FLOAT",
+                "env_var_type": "float",
+            },
+            "token5": {
+                "type": "env",
+                "key": "TEST_ENV_VAR_BYTES",
+                "env_var_type": "bytes",
+            },
+        }
+    )
+
+    assert config["token1"] == "should_be_a_string"
+    assert config["token2"] == "should_also_be_a_string"
+    assert config["token3"] == int(1000)
+    assert config["token4"] == 30.54321
+    assert config["token5"] == b"these_are_bytes"

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tempfile
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -10,8 +11,8 @@ from chaoslib.configuration import load_configuration
 from chaoslib.exceptions import InvalidExperiment
 
 
+@patch.dict("os.environ", {"KUBE_TOKEN": "value2"})
 def test_should_load_configuration():
-    os.environ["KUBE_TOKEN"] = "value2"
     config = load_configuration(
         {
             "token1": "value1",
@@ -25,9 +26,8 @@ def test_should_load_configuration():
     assert config["token3"] == "value3"
 
 
+@patch.dict("os.environ", {"KUBE_TOKEN": "value2"})
 def test_should_load_configuration_with_empty_string_as_default():
-    os.environ.clear()
-    os.environ["KUBE_TOKEN"] = "value2"
     config = load_configuration(
         {
             "token1": "value1",
@@ -41,9 +41,8 @@ def test_should_load_configuration_with_empty_string_as_default():
     assert config["token3"] == ""
 
 
+@patch.dict("os.environ", {"KUBE_TOKEN": ""})
 def test_should_load_configuration_with_empty_string_as_input():
-    os.environ.clear()
-    os.environ["KUBE_TOKEN"] = ""
     config = load_configuration(
         {
             "token1": "value1",
@@ -57,9 +56,8 @@ def test_should_load_configuration_with_empty_string_as_input():
     assert config["token3"] == "value3"
 
 
+@patch.dict("os.environ", {"KUBE_TOKEN": ""})
 def test_should_load_configuration_with_empty_string_as_input_while_default_is_define():
-    os.environ.clear()
-    os.environ["KUBE_TOKEN"] = ""
     config = load_configuration(
         {
             "token1": "value1",
@@ -73,8 +71,8 @@ def test_should_load_configuration_with_empty_string_as_input_while_default_is_d
     assert config["token3"] == "value3"
 
 
+@patch.dict("os.environ", {})
 def test_load_configuration_should_raise_exception():
-    os.environ.clear()
     with pytest.raises(InvalidExperiment) as x:
         load_configuration(
             {
@@ -90,8 +88,8 @@ def test_load_configuration_should_raise_exception():
     )
 
 
+@patch.dict("os.environ", {"KUBE_TOKEN": "value2"})
 def test_can_override_experiment_inline_config_keys():
-    os.environ["KUBE_TOKEN"] = "value2"
     config = load_configuration(
         {
             "token1": "value1",
@@ -106,8 +104,8 @@ def test_can_override_experiment_inline_config_keys():
     assert config["token3"] == "value3"
 
 
+@patch.dict("os.environ", {"KUBE_TOKEN": "value2"})
 def test_default_value_is_overriden_in_inline_config_keys():
-    os.environ["KUBE_TOKEN"] = "value2"
     config = load_configuration(
         {
             "token1": "value1",
@@ -217,8 +215,8 @@ def test_convert_invalid_type():
         convert_vars(["todo:object=stuff"])
 
 
+@patch.dict("os.environ", {"KUBE_TOKEN": "value2"})
 def test_should_override_load_configuration_with_var():
-    os.environ["KUBE_TOKEN"] = "value2"
     config = load_configuration(
         {
             "token1": "value1",
@@ -235,7 +233,6 @@ def test_should_override_load_configuration_with_var():
 
 # see https://github.com/chaostoolkit/chaostoolkit-lib/issues/195
 def test_load_nested_object_configuration():
-    os.environ.clear()
     config = load_configuration(
         {"nested": {"onea": "fdsfdsf", "lol": {"haha": [1, 2, 3]}}}
     )


### PR DESCRIPTION
This PR adds support for `env_var_type` to be a key in the declaration of configuration values
which are of `type`:`env`. Supported types are the same as `extra_vars`: `str, int, float, bytes`
