### PR TITLE
fix(hypothesis): clear up error message when expect fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.39.0...HEAD
 
+### Changed:
+
+- When working with `jsonpath` tolerances and substitutions like `${myvalue}`
+  `chaostoolkit` now gives the user an error message with all substituted values when the 
+  `expect` block does not match the output of the `probe`.
+
 ## [1.39.0][] - 2023-09-12
 
 [1.39.0]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.38.0...1.39.0

--- a/chaoslib/hypothesis.py
+++ b/chaoslib/hypothesis.py
@@ -374,10 +374,10 @@ def _(
                 result = values == expect
 
         if result is False:
-            if "expect" in tolerance:
+            if expect:
                 logger.debug(
                     "jsonpath found '{}' but expected '{}'".format(
-                        str(values), str(tolerance["expect"])
+                        str(values), str(expect)
                     )
                 )
             else:


### PR DESCRIPTION
If the `expect` string includes strings that should be replaced the debug/error message should include the final `expect` string where all placeholders are substituted. Otherwise the user is lead to believe that the substitution itself failed.