### PR TITLE
fix(controls): fix loading multiple controls from global controls file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.41.0...HEAD
 
+### Fixed
+
+- Fixed loading of multiple controls from a global control file.
+
 ## [1.41.0][] - 2023-11-16
 
 [1.41.0]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.40.0...1.41.0

--- a/chaoslib/control/__init__.py
+++ b/chaoslib/control/__init__.py
@@ -243,7 +243,7 @@ def load_global_controls(settings: Settings, control_files: Optional[List[str]] 
                 if not mod:
                     continue
 
-        controls.append(control)
+            controls.append(control)
 
     set_global_controls(controls)
 

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -634,6 +634,38 @@ def test_loading_control_file():
         cleanup_global_controls()
 
 
+def test_loading_multiple_controls_from_control_file():
+    try:
+        assert get_global_controls() == []
+        settings = {}
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(
+                json.dumps(
+                    {
+                        "dummy_sums": {
+                            "provider": {
+                                "type": "python",
+                                "module": "fixtures.controls.dummy_sums",
+                            }
+                        },
+                        "dummy_sums_2": {
+                            "provider": {
+                                "type": "python",
+                                "module": "fixtures.controls.dummy_sums",
+                            }
+                        },
+                    }
+                ).encode("utf-8")
+            )
+            f.seek(0)
+
+            load_global_controls(settings, [f.name])
+
+        assert len(get_global_controls()) == 2
+    finally:
+        cleanup_global_controls()
+
+
 def test_running_in_order():
     try:
         assert get_global_controls() == []


### PR DESCRIPTION
This commit fixes loading multiple controls from a global control file as well as add a test for this behaviour.